### PR TITLE
Updating dwarfs targets and rosters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
   - "2.7"
-  - "3.6"
+  - "3.7"
 #  - "nightly" # currently points to 3.6-dev
 
 sudo: false

--- a/dmsky/data/targets/dwarfs/census2020.yaml
+++ b/dmsky/data/targets/dwarfs/census2020.yaml
@@ -1,0 +1,375 @@
+# Photo-J calculated from Pace & Strigari 2018 Eq 14:
+# photo-J = 10**18.17 * (Lv/1e4 Lsun)**0.23 * (d/100kpc)**-2 * (rh/100pc)**-0.5
+# j_sigma = 0.3 is the scatter of the Pace & Strigari fit
+
+antlia_II:
+  census2020_photoj_nfw:
+    j_integ: 4.022e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+aquarius_II:
+  census2020_photoj_nfw:
+    j_integ: 9.720e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+bootes_I:
+  census2020_photoj_nfw:
+    j_integ: 3.200e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+bootes_II:
+  census2020_photoj_nfw:
+    j_integ: 9.191e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+bootes_III:
+  census2020_photoj_nfw:
+    j_integ: 4.493e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+bootes_IV:
+  census2020_photoj_nfw:
+    j_integ: 1.778e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+canes_venatici_I:
+  census2020_photoj_nfw:
+    j_integ: 3.662e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+canes_venatici_II:
+  census2020_photoj_nfw:
+    j_integ: 7.805e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+canis_major:
+  census2020_photoj_nfw:
+    j_integ: nan
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+carina:
+  census2020_photoj_nfw:
+    j_integ: 2.106e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+carina_II:
+  census2020_photoj_nfw:
+    j_integ: 1.144e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+carina_III:
+  census2020_photoj_nfw:
+    j_integ: 2.360e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+centaurus_I:
+  census2020_photoj_nfw:
+    j_integ: 1.357e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+cetus_II:
+  census2020_photoj_nfw:
+    j_integ: 1.361e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+cetus_III:
+  census2020_photoj_nfw:
+    j_integ: 2.007e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+columba_I:
+  census2020_photoj_nfw:
+    j_integ: 3.643e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+coma_berenices:
+  census2020_photoj_nfw:
+    j_integ: 8.490e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+crater_II:
+  census2020_photoj_nfw:
+    j_integ: 6.233e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+draco:
+  census2020_photoj_nfw:
+    j_integ: 4.052e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+draco_II:
+  census2020_photoj_nfw:
+    j_integ: 3.089e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+eridanus_II:
+  census2020_photoj_nfw:
+    j_integ: 1.255e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+eridanus_III:
+  census2020_photoj_nfw:
+    j_integ: 4.854e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+fornax:
+  census2020_photoj_nfw:
+    j_integ: 1.486e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+grus_I:
+  census2020_photoj_nfw:
+    j_integ: 1.558e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+grus_II:
+  census2020_photoj_nfw:
+    j_integ: 4.183e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+hercules:
+  census2020_photoj_nfw:
+    j_integ: 8.933e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+horologium_I:
+  census2020_photoj_nfw:
+    j_integ: 3.010e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+horologium_II:
+  census2020_photoj_nfw:
+    j_integ: 2.461e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+hydra_II:
+  census2020_photoj_nfw:
+    j_integ: 7.573e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+hydrus_I:
+  census2020_photoj_nfw:
+    j_integ: 2.443e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+indus_II:
+  census2020_photoj_nfw:
+    j_integ: 2.004e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+kim_2:
+  census2020_photoj_nfw:
+    j_integ: 2.946e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+laevens_1:
+  census2020_photoj_nfw:
+    j_integ: 1.469e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+laevens_3:
+  census2020_photoj_nfw:
+    j_integ: 1.052e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+leo_I:
+  census2020_photoj_nfw:
+    j_integ: 6.191e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+leo_II:
+  census2020_photoj_nfw:
+    j_integ: 5.571e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+leo_IV:
+  census2020_photoj_nfw:
+    j_integ: 5.877e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+leo_T:
+  census2020_photoj_nfw:
+    j_integ: 1.414e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+leo_V:
+  census2020_photoj_nfw:
+    j_integ: 6.361e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+pegasus_III:
+  census2020_photoj_nfw:
+    j_integ: 3.407e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+phoenix_II:
+  census2020_photoj_nfw:
+    j_integ: 3.178e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+pictor_I:
+  census2020_photoj_nfw:
+    j_integ: 1.885e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+pictor_II:
+  census2020_photoj_nfw:
+    j_integ: 6.797e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+pisces_II:
+  census2020_photoj_nfw:
+    j_integ: 5.261e+17
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+reticulum_II:
+  census2020_photoj_nfw:
+    j_integ: 2.201e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+reticulum_III:
+  census2020_photoj_nfw:
+    j_integ: 1.483e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+sagittarius:
+  census2020_photoj_nfw:
+    j_integ: 3.153e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+sagittarius_II:
+  census2020_photoj_nfw:
+    j_integ: 5.477e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+sculptor:
+  census2020_photoj_nfw:
+    j_integ: 4.656e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+segue_1:
+  census2020_photoj_nfw:
+    j_integ: 2.797e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+segue_2:
+  census2020_photoj_nfw:
+    j_integ: 1.030e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+sextans:
+  census2020_photoj_nfw:
+    j_integ: 2.289e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+triangulum_II:
+  census2020_photoj_nfw:
+    j_integ: 2.142e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+tucana_II:
+  census2020_photoj_nfw:
+    j_integ: 2.610e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+tucana_III:
+  census2020_photoj_nfw:
+    j_integ: 1.953e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+tucana_IV:
+  census2020_photoj_nfw:
+    j_integ: 3.969e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+tucana_V:
+  census2020_photoj_nfw:
+    j_integ: 5.727e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+ursa_major_I:
+  census2020_photoj_nfw:
+    j_integ: 1.260e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+ursa_major_II:
+  census2020_photoj_nfw:
+    j_integ: 1.278e+19
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+ursa_minor:
+  census2020_photoj_nfw:
+    j_integ: 3.498e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+virgo_I:
+  census2020_photoj_nfw:
+    j_integ: 1.167e+18
+    j_sigma: 0.3
+    profile: {type: NFW}
+
+willman_1:
+  census2020_photoj_nfw:
+    j_integ: 1.303e+19
+    j_sigma: 0.3
+    profile: {type: NFW}

--- a/dmsky/data/targets/dwarfs/defaults.yaml
+++ b/dmsky/data/targets/dwarfs/defaults.yaml
@@ -32,6 +32,7 @@ bootes_I:
     major_axis: 12.60 # arcmin
     ellipticity: 0.39
     abs_mag: -6.31
+    profile: {type: NFW}
 
 bootes_II:
   default:
@@ -47,6 +48,7 @@ bootes_II:
     major_axis: 4.20 # arcmin
     ellipticity: 0.21
     abs_mag: -2.70
+    profile: {type: NFW}
 
 bootes_III:
   default:
@@ -62,6 +64,7 @@ bootes_III:
     major_axis: .nan
     ellipticity: 0.50
     abs_mag: -5.8
+    profile: {type: NFW}
 
 canes_venatici_I:
   default:
@@ -77,6 +80,7 @@ canes_venatici_I:
     major_axis: 8.90
     ellipticity: 0.39
     abs_mag: -8.59
+    profile: {type: NFW}
 
 canes_venatici_II:
   default:
@@ -93,6 +97,7 @@ canes_venatici_II:
     major_axis: 1.60
     ellipticity: 0.52
     abs_mag: -4.92
+    profile: {type: NFW}
 
 canis_major:
   default:
@@ -108,6 +113,7 @@ canis_major:
     major_axis: .nan
     ellipticity: 0.80
     abs_mag: -14.4
+    profile: {type: NFW}
 
 carina:
   default:
@@ -123,6 +129,7 @@ carina:
     major_axis: 8.20 # arcmin
     ellipticity: 0.33 
     abs_mag: -9.11
+    profile: {type: NFW}
 
 coma_berenices:
   default:
@@ -138,6 +145,7 @@ coma_berenices:
     major_axis: 6.0
     ellipticity: 0.38
     abs_mag: -4.10
+    profile: {type: NFW}
 
 draco:
   default:
@@ -154,6 +162,7 @@ draco:
     major_axis: 10.00
     ellipticity: 0.31
     abs_mag: -8.80
+    profile: {type: NFW}
 
 fornax:
   default:
@@ -169,6 +178,7 @@ fornax:
     major_axis: 16.60
     ellipticity: 0.30
     abs_mag: -13.44
+    profile: {type: NFW}
 
 hercules:
   default:
@@ -184,6 +194,7 @@ hercules:
     major_axis: 8.60
     ellipticity: 0.68
     abs_mag: -6.60
+    profile: {type: NFW}
 
 leo_I:
   default:
@@ -199,6 +210,7 @@ leo_I:
     major_axis: 3.40
     ellipticity: 0.21
     abs_mag: -12.02
+    profile: {type: NFW}
 
 leo_II:
   default:
@@ -214,6 +226,7 @@ leo_II:
     major_axis: 2.60
     ellipticity: 0.13
     abs_mag: -9.84
+    profile: {type: NFW}
 
 leo_IV:
   default:
@@ -229,6 +242,7 @@ leo_IV:
     major_axis: 4.60
     ellipticity: 0.49
     abs_mag: -5.84
+    profile: {type: NFW}
 
 leo_T:
   default:
@@ -243,6 +257,7 @@ leo_T:
     dsigma: 19.
     major_axis: 0.99
     ellipticity: 0.0
+    profile: {type: NFW}
 
 leo_V:
   default:
@@ -258,6 +273,7 @@ leo_V:
     major_axis: 2.6
     ellipticity: 0.5
     abs_mag: -5.25
+    profile: {type: NFW}
 
 pisces_II:
   default:
@@ -273,6 +289,7 @@ pisces_II:
     major_axis: 1.10
     ellipticity: 0.40
     abs_mag: -5.00
+    profile: {type: NFW}
  
 sagittarius:
   default:
@@ -289,6 +306,7 @@ sagittarius:
     major_axis: 342.0
     ellipticity: 0.64
     abs_mag: -13.5
+    profile: {type: NFW}
 
 sculptor:
   default:
@@ -304,6 +322,7 @@ sculptor:
     major_axis: 11.30
     ellipticity: 0.32
     abs_mag: -11.07
+    profile: {type: NFW}
  
 segue_1:
   default:
@@ -320,6 +339,7 @@ segue_1:
     major_axis: 4.40
     ellipticity: 0.48
     abs_mag: -1.50
+    profile: {type: NFW}
 
 segue_2:
   default:
@@ -335,6 +355,7 @@ segue_2:
     major_axis: 3.40
     ellipticity: 0.15
     abs_mag: -2.5
+    profile: {type: NFW}
 
 sextans:
   default:
@@ -350,6 +371,7 @@ sextans:
     major_axis: 27.80
     ellipticity: 0.35
     abs_mag: -9.27
+    profile: {type: NFW}
 
 ursa_major_I:
   default:
@@ -366,6 +388,7 @@ ursa_major_I:
     major_axis: 11.30
     ellipticity: 0.80
     abs_mag: -5.53
+    profile: {type: NFW}
 
 ursa_major_II:
   default:
@@ -382,6 +405,7 @@ ursa_major_II:
     major_axis: 16.00
     ellipticity: 0.63
     abs_mag: -4.20
+    profile: {type: NFW}
 
 ursa_minor:
   default:
@@ -397,6 +421,7 @@ ursa_minor:
     major_axis: 8.20
     ellipticity: 0.56
     abs_mag: -8.80
+    profile: {type: NFW}
 
 willman_1: 
   default:
@@ -412,6 +437,7 @@ willman_1:
     major_axis: 2.30
     ellipticity: 0.47
     abs_mag: -2.70
+    profile: {type: NFW}
 
 eridanus_II:
   default:
@@ -429,8 +455,7 @@ eridanus_II:
     major_axis: 1.80
     ellipticity: 0.19
     abs_mag: -7.40
-
-
+    profile: {type: NFW}
   
 eridanus_III:
   default:
@@ -447,6 +472,7 @@ eridanus_III:
     major_axis: 0.42 
     ellipticity: .nan
     abs_mag: -2.39
+    profile: {type: NFW}
 
 grus_I:
   default:
@@ -463,6 +489,7 @@ grus_I:
     major_axis: 2.23
     ellipticity: 0.41
     abs_mag: -3.4
+    profile: {type: NFW}
       
 horologium_I:
   default:
@@ -480,6 +507,7 @@ horologium_I:
     major_axis: 2.40
     ellipticity: .nan
     abs_mag: -3.52
+    profile: {type: NFW}
 
 horologium_II:
   default:
@@ -495,6 +523,7 @@ horologium_II:
     major_axis: 2.09
     ellipticity: 0.52
     abs_mag: -2.6
+    profile: {type: NFW}
 
 pegasus_III:
   default:
@@ -510,6 +539,7 @@ pegasus_III:
     major_axis: 1.30
     ellipticity: 0.46
     abs_mag: -4.1
+    profile: {type: NFW}
 
 pictor_I:
   default:
@@ -526,6 +556,7 @@ pictor_I:
     major_axis: 1.20
     ellipticity: .nan
     abs_mag: -3.68
+    profile: {type: NFW}
 
 phoenix_II:
   default:
@@ -542,6 +573,7 @@ phoenix_II:
     major_axis: 1.20
     ellipticity: .nan
     abs_mag: -3.72
+    profile: {type: NFW}
 
 hydra_II:
   default:
@@ -558,6 +590,7 @@ hydra_II:
     major_axis: 1.70
     ellipticity: 0.01
     abs_mag: -4.80
+    profile: {type: NFW}
 
 reticulum_II:
   default:
@@ -573,6 +606,7 @@ reticulum_II:
     dsigma: 3.
     major_axis: 6.00
     ellipticity: 0.6
+    profile: {type: NFW}
 
 triangulum_II:
   default:
@@ -588,6 +622,7 @@ triangulum_II:
     major_axis: 3.90
     ellipticity: 0.21
     abs_mag: -1.80
+    profile: {type: NFW}
 
 laevens_3:
   default:
@@ -603,6 +638,7 @@ laevens_3:
     major_axis: 0.40
     ellipticity: 0.21
     abs_mag: -4.4
+    profile: {type: NFW}
 
 draco_II:
   default:
@@ -618,6 +654,7 @@ draco_II:
     major_axis: 2.70
     ellipticity: 0.24
     abs_mag: -2.9
+    profile: {type: NFW}
 
 sagittarius_II:
   default:
@@ -633,6 +670,7 @@ sagittarius_II:
     major_axis: 2.00
     ellipticity: 0.23
     abs_mag: -5.2
+    profile: {type: NFW}
 
 kim_2:
   default:
@@ -649,6 +687,7 @@ kim_2:
     major_axis: 0.42
     ellipticity: 0.12
     abs_mag: -1.5
+    profile: {type: NFW}
 
 tucana_II:
   default:
@@ -665,6 +704,7 @@ tucana_II:
     major_axis: 7.20
     ellipticity: .nan
     abs_mag: -3.90
+    profile: {type: NFW}
 
 tucana_III:
   default:
@@ -681,6 +721,7 @@ tucana_III:
     major_axis: 6.00
     ellipticity: .nan
     abs_mag: -2.36
+    profile: {type: NFW}
 
 tucana_IV:
   default:
@@ -698,6 +739,7 @@ tucana_IV:
     major_axis: 11.80
     ellipticity: 0.40
     abs_mag: -3.46
+    profile: {type: NFW}
 
 tucana_V:
   default:
@@ -714,6 +756,7 @@ tucana_V:
     major_axis: 1.80
     ellipticity: 0.70
     abs_mag: -1.62
+    profile: {type: NFW}
       
 columba_I:
   default:
@@ -731,6 +774,7 @@ columba_I:
     major_axis: 1.90
     ellipticity: .nan
     abs_mag: -4.54
+    profile: {type: NFW}
 
 grus_II:
   default:
@@ -748,6 +792,7 @@ grus_II:
     major_axis: 6.0
     ellipticity: 0.0
     abs_mag: -3.90
+    profile: {type: NFW}
 
 reticulum_III:
   default:
@@ -765,6 +810,7 @@ reticulum_III:
     major_axis: 2.40
     ellipticity: .nan
     abs_mag: -3.30
+    profile: {type: NFW}
       
 indus_II:
   default:
@@ -781,6 +827,7 @@ indus_II:
     major_axis: 2.90
     ellipticity: .nan
     abs_mag: -4.27
+    profile: {type: NFW}
 
 cetus_II:
   default:
@@ -797,6 +844,7 @@ cetus_II:
     major_axis: 1.9
     ellipticity: .nan
     abs_mag: 0.0
+    profile: {type: NFW}
 
 crater_II:
   default:
@@ -813,6 +861,7 @@ crater_II:
     major_axis: 31.2
     ellipticity: .nan
     abs_mag: -8.2
+    profile: {type: NFW}
   
 aquarius_II:
   default:
@@ -828,6 +877,7 @@ aquarius_II:
     major_axis: 5.1
     ellipticity: 0.4
     abs_mag: -4.2
+    profile: {type: NFW}
 
 # 1609.02148
 pictor_II:
@@ -844,6 +894,7 @@ pictor_II:
     major_axis: 3.8
     ellipticity: 0.13
     abs_mag: -3.2
+    profile: {type: NFW}
 
 # 1609.04346
 virgo_I:
@@ -860,6 +911,7 @@ virgo_I:
     major_axis: 1.5
     ellipticity: 0.44
     abs_mag: -0.8
+    profile: {type: NFW}
 
 # 1704.05977
 cetus_III:
@@ -876,6 +928,7 @@ cetus_III:
     major_axis: 1.23
     ellipticity: 0.44
     abs_mag: -2.45
+    profile: {type: NFW}
 
 # 1801.07279
 carina_II:
@@ -892,6 +945,7 @@ carina_II:
     major_axis: 8.69
     ellipticity: 0.34
     abs_mag: -4.5
+    profile: {type: NFW}
 
 # 1801.07279
 carina_III:
@@ -908,6 +962,7 @@ carina_III:
     major_axis: 3.75
     ellipticity: 0.55
     abs_mag: -2.4
+    profile: {type: NFW}
 
 # 1804.06430
 hydrus_I:
@@ -924,6 +979,7 @@ hydrus_I:
     major_axis: 7.42
     ellipticity: 0.21
     abs_mag: -4.71
+    profile: {type: NFW}
       
 # NED object query names
 #bootes I

--- a/dmsky/data/targets/dwarfs/defaults2020.yaml
+++ b/dmsky/data/targets/dwarfs/defaults2020.yaml
@@ -1,0 +1,1010 @@
+# Default set of dwarf characterisitcs.
+# All dwarfs should appear in this file.
+#
+#key:
+#  default:
+#    type:         dwarf or cluster
+#    title:        full name
+#    abbr:         IAU abbreviation
+#    name:         codename
+#    color:        display color
+#    ra:           right ascension (deg)
+#    dec:          declination (deg)
+#    distance:     distance (kpc)
+#    dsigma:       distance uncertainty (kpc)
+#    major_axis:   semi-major half-light radius (arcmin)
+#    ellipticity:  ellipticity
+#    abs_mag:      absolute magnitude (mag)
+#    profile:      density profile type
+
+antlia_II:
+  default:
+    type:         dwarf
+    title:        'Antlia II'
+    abbr:         'Ant I'
+    name:         'antlia_II'
+    color:        'blue'
+    ra:  143.8868
+    dec: -36.7673
+    distance: 131.8
+    dsigma: 6.0
+    major_axis: 76.2
+    ellipticity: 0.38
+    abs_mag: -9.03
+    profile: {type: NFW}
+
+aquarius_II:
+  default:
+    type:         dwarf
+    title:        'Aquarius II'
+    abbr:         'Aqr II'
+    name:         'aquarius_II'
+    color:        'cyan'
+    ra:  338.4813
+    dec: -9.3274
+    distance: 107.6
+    dsigma: 3.3
+    major_axis: 5.1
+    ellipticity: 0.39
+    abs_mag: -4.4
+    profile: {type: NFW}
+
+bootes_I:
+  default:
+    type:         dwarf
+    title:        'Bootes I'
+    abbr:         'Boo I'
+    name:         'bootes_I'
+    color:        'blue'
+    ra:  210.02
+    dec: 14.5135
+    distance: 66.1
+    dsigma: 2.0
+    major_axis: 9.97
+    ellipticity: 0.3
+    abs_mag: -6.02
+    profile: {type: NFW}
+
+bootes_II:
+  default:
+    type:         dwarf
+    title:        'Bootes II'
+    abbr:         'Boo II'
+    name:         'bootes_II'
+    color:        'mediumblue'
+    ra:  209.5141
+    dec: 12.8553
+    distance: 41.7
+    dsigma: 1.0
+    major_axis: 3.17
+    ellipticity: 0.25
+    abs_mag: -2.94
+    profile: {type: NFW}
+
+bootes_III:
+  default:
+    type:         dwarf
+    title:        'Bootes III'
+    abbr:         'Boo III'
+    name:         'bootes_III'
+    color:        'darkblue'
+    ra:  209.3
+    dec: 26.8
+    distance: 46.8
+    dsigma: 2.0
+    major_axis: 30
+    ellipticity: 0.5
+    abs_mag: -5.75
+    profile: {type: NFW}
+
+bootes_IV:
+  default:
+    type:         dwarf
+    title:        'Bootes IV'
+    abbr:         'Boo IV'
+    name:         'bootes_IV'
+    color:        'darkblue'
+    ra:  233.689
+    dec: 43.726
+    distance: 208.9
+    dsigma: 19.0
+    major_axis: 7.6
+    ellipticity: 0.64
+    abs_mag: -4.53
+    profile: {type: NFW}
+
+canis_major:
+  default:
+    type:         dwarf
+    title:        'Canis Major'
+    abbr:         'CMa'
+    name:         'canis_major'
+    color:        'SlateBlue'
+    ra:  108.1458333
+    dec: -27.66666667
+    distance: 7.2
+    dsigma: 1.0
+    major_axis: .nan
+    ellipticity: .nan
+    abs_mag: -14.39
+    profile: {type: NFW}
+
+canes_venatici_I:
+  default:
+    type:         dwarf
+    title:        'Canes Venatici I'
+    abbr:         'CVn I'
+    name:         'canes_venatici_I'
+    color:        'dodgerblue'
+    ra:  202.0091
+    dec: 33.5521
+    distance: 217.8
+    dsigma: 10.0
+    major_axis: 7.12
+    ellipticity: 0.44
+    abs_mag: -8.8
+    profile: {type: NFW}
+
+canes_venatici_II:
+  default:
+    type:         dwarf
+    title:        'Canes Venatici II'
+    abbr:         'CVn II'
+    name:         'canes_venatici_II'
+    color:        'steelblue'
+    ra:  194.2927
+    dec: 34.3226
+    distance: 160.0
+    dsigma: 4.0
+    major_axis: 1.52
+    ellipticity: 0.4
+    abs_mag: -5.17
+    profile: {type: NFW}
+
+carina:
+  default:
+    type:         dwarf
+    title:        'Carina'
+    abbr:         'Car'
+    name:         'carina'
+    color:        'mediumslateblue'
+    ra:  100.4065
+    dec: -50.9593
+    distance: 105.0
+    dsigma: 6.0
+    major_axis: 10.1
+    ellipticity: 0.36
+    abs_mag: -9.43
+    profile: {type: NFW}
+
+carina_II:
+  default:
+    type:         dwarf
+    title:        'Carina II'
+    abbr:         'Car II'
+    name:         'carina_II'
+    color:        'cyan'
+    ra:  114.1066
+    dec: -57.9991
+    distance: 36.1
+    dsigma: 0.6
+    major_axis: 8.69
+    ellipticity: 0.34
+    abs_mag: -4.5
+    profile: {type: NFW}
+
+carina_III:
+  default:
+    type:         dwarf
+    title:        'Carina III'
+    abbr:         'Car III'
+    name:         'carina_III'
+    color:        'cyan'
+    ra:  114.6298
+    dec: -57.8997
+    distance: 27.8
+    dsigma: 0.6
+    major_axis: 3.75
+    ellipticity: 0.55
+    abs_mag: -2.4
+    profile: {type: NFW}
+
+centaurus_I:
+  default:
+    type:         dwarf
+    title:        'Centarus I'
+    abbr:         'Cen I'
+    name:         'centaurus_I'
+    color:        'cyan'
+    ra:  189.585
+    dec: -40.902
+    distance: 116.4
+    dsigma: 1.1
+    major_axis: 2.9
+    ellipticity: 0.4
+    abs_mag: -5.55
+    profile: {type: NFW}
+
+cetus_II:
+  default:
+    type:         dwarf
+    title:        'Cetus II'
+    abbr:         'Cet II'
+    name:         'cetus_II'
+    color:        'cyan'
+    ra:  19.47
+    dec: -17.42
+    distance: 29.9
+    dsigma: 3.0
+    major_axis: 1.9
+    ellipticity: 0 # < 0.4
+    abs_mag: 0.0
+    profile: {type: NFW}
+
+cetus_III:
+  default:
+    type:         dwarf
+    title:        'Cetus III'
+    abbr:         'Cet III'
+    name:         'cetus_III'
+    color:        'cyan'
+    ra:  31.331
+    dec: -4.27
+    distance: 251.2
+    dsigma: 17.5
+    major_axis: 1.23
+    ellipticity: 0.76
+    abs_mag: -2.5
+    profile: {type: NFW}
+
+columba_I:
+  default:
+    type:         dwarf
+    title:        'Columba I'
+    abbr:         'Col I'
+    name:         'columba_I'
+    color:        'gray'
+    ra:  82.86
+    dec: -28.01
+    distance: 182.8
+    dsigma: 18.0
+    major_axis: 2.2
+    ellipticity: 0.3
+    abs_mag: -4.2
+    profile: {type: NFW}
+
+coma_berenices:
+  default:
+    type:         dwarf
+    title:        'Coma Berenices'
+    abbr:         'Com'
+    name:         'coma_berenices'
+    color:        'green'
+    ra:  186.7454
+    dec: 23.9069
+    distance: 44.1
+    dsigma: 4.0
+    major_axis: 5.64
+    ellipticity: 0.37
+    abs_mag: -4.38
+    profile: {type: NFW}
+
+crater_II:
+  default:
+    type:         dwarf
+    title:        'Crater II'
+    abbr:         'Crt II'
+    name:         'crater_II'
+    color:        'cyan'
+    ra:  177.31
+    dec: -18.413
+    distance: 117.5
+    dsigma: 1.1
+    major_axis: 31.2
+    ellipticity: 0 # < 0.1
+    abs_mag: -8.2
+    profile: {type: NFW}
+
+draco:
+  default:
+    type:         dwarf
+    title:        'Draco'
+    abbr:         'Dra'
+    name:         'draco'
+    color:        'chartreuse'
+    ra:  260.0684
+    dec: 57.9185
+    distance: 75.9
+    dsigma: 6.0
+    major_axis: 9.67
+    ellipticity: 0.29
+    abs_mag: -8.71
+    profile: {type: NFW}
+
+draco_II:
+  default:
+    type:         dwarf
+    title:        'Draco II'
+    abbr:         'Dra II'
+    name:         'draco_II'
+    color:        'dodgerblue'
+    ra:  238.174
+    dec: 64.579
+    distance: 21.6
+    dsigma: 3
+    major_axis: 3
+    ellipticity: 0.23
+    abs_mag: -0.8
+    profile: {type: NFW}
+
+eridanus_II:
+  default:
+    type:         dwarf
+    title:        'Eridanus II'
+    abbr:         'Eri II'
+    name:         'eridanus_II'
+    color:        'crimson'
+    ra:  56.0925
+    dec: -43.5329
+    distance: 380.2
+    dsigma: 30.0
+    major_axis: 1.77
+    ellipticity: 0.35
+    abs_mag: -7.21
+    profile: {type: NFW}
+
+eridanus_III:
+  default:
+    type:         dwarf
+    title:        'Eridanus III'
+    abbr:         'Eri III'
+    name:         'eridanus_III'
+    color:        'slategrey'
+    ra:  35.6952
+    dec: -52.2838
+    distance: 87.1
+    dsigma: 10.0
+    major_axis: 0.3
+    ellipticity: 0.58
+    abs_mag: -2.37
+    profile: {type: NFW}
+
+fornax:
+  default:
+    type:         dwarf
+    title:        'Fornax'
+    abbr:         'For'
+    name:         'fornax'
+    color:        'magenta'
+    ra:  39.9583
+    dec: -34.4997
+    distance: 147.2
+    dsigma: 12.0
+    major_axis: 19.6
+    ellipticity: 0.29
+    abs_mag: -13.46
+    profile: {type: NFW}
+
+grus_I:
+  default:
+    type:         dwarf
+    title:        'Grus I'
+    abbr:         'Gru I'
+    name:         'grus_I'
+    color:        'purple'
+    ra:  344.1797
+    dec: -50.18
+    distance: 120.2
+    dsigma: 12
+    major_axis: 0.81
+    ellipticity: 0.45
+    abs_mag: -3.47
+    profile: {type: NFW}
+
+grus_II:
+  default:
+    type:         dwarf
+    title:        'Grus II'
+    abbr:         'Gru II'
+    name:         'grus_II'
+    color:        'magenta'
+    ra:  331.02
+    dec: -46.44
+    distance: 53.0
+    dsigma: 5.0
+    major_axis: 6
+    ellipticity: 0 # < 0.2
+    abs_mag: -3.9
+    profile: {type: NFW}
+
+hercules:
+  default:
+    type:         dwarf
+    title:        'Hercules'
+    abbr:         'Her'
+    name:         'hercules'
+    color:        'orchid'
+    ra:  247.7722
+    dec: 12.7852
+    distance: 131.8
+    dsigma: 12.0
+    major_axis: 5.63
+    ellipticity: 0.69
+    abs_mag: -5.83
+    profile: {type: NFW}
+
+horologium_I:
+  default:
+    type:         dwarf
+    title:        'Horologium I'
+    abbr:         'Hor I'
+    name:         'horologium_I'
+    color:        'tan'
+    ra:  43.8813
+    dec: -54.116
+    distance: 79.0
+    dsigma: 8.0
+    major_axis: 1.59
+    ellipticity: 0.27
+    abs_mag: -3.55
+    profile: {type: NFW}
+
+horologium_II:
+  default:
+    type:         dwarf
+    title:        'Horologium II'
+    abbr:         'Hor II'
+    name:         'horologium_II'
+    color:        'gold'
+    ra:  49.1077
+    dec: -50.0486
+    distance: 78.0
+    dsigma: 8.0
+    major_axis: 2.09
+    ellipticity: 0.52
+    abs_mag: -2.6
+    profile: {type: NFW}
+
+hydra_II:
+  default:
+    type:         dwarf
+    title:        'Hydra II'
+    abbr:         'Hya II'
+    name:         'hydra_II'
+    color:        'dodgerblue'
+    ra:  185.4251
+    dec: -31.986
+    distance: 150.7
+    dsigma: 10
+    major_axis: 1.52
+    ellipticity: 0.24
+    abs_mag: -4.6
+    profile: {type: NFW}
+
+hydrus_I:
+  default:
+    type:         dwarf
+    title:        'Hydrus I'
+    abbr:         'Hyi I'
+    name:         'hydrus_I'
+    color:        'cyan'
+    ra:  37.389
+    dec: -79.3089
+    distance: 27.5
+    dsigma: 0.5
+    major_axis: 7.42
+    ellipticity: 0.21
+    abs_mag: -4.71
+    profile: {type: NFW}
+
+indus_II:
+  default:
+    type:         dwarf
+    title:        'Indus II'
+    abbr:         'Ind II'
+    name:         'indus_II'
+    color:        'indigo'
+    ra:  309.72
+    dec: -46.16
+    distance: 213.8
+    dsigma: 16.0
+    major_axis: 2.9
+    ellipticity: 0 # < 0.4
+    abs_mag: -4.3
+    profile: {type: NFW}
+
+kim_2:
+  default:
+    type:         dwarf
+    title:        'Kim 2'
+    abbr:         'Kim2'
+    name:         'kim_2'
+    color:        'indianred'
+    ra:  317.202
+    dec: -51.1671
+    distance: 100.0
+    dsigma: 7.0
+    major_axis: 0.48
+    ellipticity: 0.32
+    abs_mag: -3.32
+    profile: {type: NFW}
+
+laevens_1:
+  default:
+    type:         dwarf
+    title:        'Laevens 1'
+    abbr:         'Lae 1'
+    name:         'laevens_1'
+    color:        'dodgerblue'
+    ra:  174.0668
+    dec: -10.8772
+    distance: 145.0
+    dsigma: 17.0
+    major_axis: 0.51
+    ellipticity: 0.17
+    abs_mag: -4.8
+    profile: {type: NFW}
+
+laevens_3:
+  default:
+    type:         dwarf
+    title:        'Laevens 3'
+    abbr:         'Lae 3'
+    name:         'laevens_3'
+    color:        'dodgerblue'
+    ra:  316.7263
+    dec: 14.98
+    distance: 67.3
+    dsigma: 3
+    major_axis: 0.4
+    ellipticity: 0.21
+    abs_mag: -4.4
+    profile: {type: NFW}
+
+leo_I:
+  default:
+    type:         dwarf
+    title:        'Leo I'
+    abbr:         'Leo I'
+    name:         'leo_I'
+    color:        'gold'
+    ra:  152.1146
+    dec: 12.3059
+    distance: 254.0
+    dsigma: 15.0
+    major_axis: 3.65
+    ellipticity: 0.3
+    abs_mag: -11.78
+    profile: {type: NFW}
+
+leo_II:
+  default:
+    type:         dwarf
+    title:        'Leo II'
+    abbr:         'Leo II'
+    name:         'leo_II'
+    color:        'goldenrod'
+    ra:  168.3627
+    dec: 22.1529
+    distance: 233.3
+    dsigma: 14.0
+    major_axis: 2.52
+    ellipticity: 0.07
+    abs_mag: -9.74
+    profile: {type: NFW}
+
+leo_IV:
+  default:
+    type:         dwarf
+    title:        'Leo IV'
+    abbr:         'Leo IV'
+    name:         'leo_IV'
+    color:        '#C58917'
+    ra:  173.2405
+    dec: -0.5453
+    distance: 154.2
+    dsigma: 6.0
+    major_axis: 2.54
+    ellipticity: 0.17
+    abs_mag: -4.99
+    profile: {type: NFW}
+
+leo_V:
+  default:
+    type:         dwarf
+    title:        'Leo V'
+    abbr:         'Leo V'
+    name:         'leo_V'
+    color:        'Peru'
+    ra:  172.7857
+    dec: 2.2194
+    distance: 177.8
+    dsigma: 10.0
+    major_axis: 1
+    ellipticity: 0.43
+    abs_mag: -4.4
+    profile: {type: NFW}
+
+leo_T:
+  default:
+    type:         dwarf
+    title:        'Leo T'
+    abbr:         'Leo T'
+    name:         'leo_T'
+    color:        'gold2'
+    ra: 143.7225
+    dec: 17.05139
+    distance: 417.0
+    dsigma: 19.
+    major_axis: 0.99
+    ellipticity: 0.0
+    abs_mag: -8.0
+    profile: {type: NFW}
+
+pegasus_III:
+  default:
+    type:         dwarf
+    title:        'Pegasus III'
+    abbr:         'Peg III'
+    name:         'pegasus_III'
+    color:        'black'
+    ra:  336.102
+    dec: 5.405
+    distance: 214.8
+    dsigma: 20.0
+    major_axis: 0.85
+    ellipticity: 0.38
+    abs_mag: -3.4
+    profile: {type: NFW}
+
+phoenix_II:
+  default:
+    type:         dwarf
+    title:        'Phoenix II'
+    abbr:         'Phe II'
+    name:         'phoenix_II'
+    color:        'indigo'
+    ra:  354.996
+    dec: -54.4115
+    distance: 83.0
+    dsigma: 10.0
+    major_axis: 1.49
+    ellipticity: 0.67
+    abs_mag: -3.3
+    profile: {type: NFW}
+
+pictor_I:
+  default:
+    type:         dwarf
+    title:        'Pictor I'
+    abbr:         'Pic I'
+    name:         'pictor_I'
+    color:        'saddlebrown'
+    ra:  70.949
+    dec: -50.2854
+    distance: 113.8
+    dsigma: 12.0
+    major_axis: 0.88
+    ellipticity: 0.63
+    abs_mag: -3.45
+    profile: {type: NFW}
+
+pictor_II:
+  default:
+    type:         dwarf
+    title:        'Pictor II'
+    abbr:         'Pic II'
+    name:         'pictor_II'
+    color:        'cyan'
+    ra:  101.18
+    dec: -59.897
+    distance: 45.7
+    dsigma: 5.0
+    major_axis: 3.8
+    ellipticity: 0.13
+    abs_mag: -3.2
+    profile: {type: NFW}
+
+pisces_II:
+  default:
+    type:         dwarf
+    title:        'Pisces II'
+    abbr:         'Psc II'
+    name:         'pisces_II'
+    color:        'chocolate'
+    ra:  344.6345
+    dec: 5.9526
+    distance: 182.0
+    dsigma: .nan
+    major_axis: 1.12
+    ellipticity: 0.34
+    abs_mag: -4.22
+    profile: {type: NFW}
+
+reticulum_II:
+  default:
+    type:         dwarf
+    title:        'Reticulum II'
+    abbr:         'Ret II'
+    name:         'reticulum_II'
+    color:        'violet'
+    ra:  53.9203
+    dec: -54.0513
+    distance: 30.2
+    dsigma: 3.0
+    major_axis: 5.52
+    ellipticity: 0.58
+    abs_mag: -3.88
+    profile: {type: NFW}
+
+reticulum_III:
+  default:
+    type:         dwarf
+    title:        'Reticulum III'
+    abbr:         'Ret III'
+    name:         'reticulum_III'
+    color:        'red'
+    ra:  56.36
+    dec: -60.45
+    distance: 91.6
+    dsigma: 13.0
+    major_axis: 2.4
+    ellipticity: 0 # < 0.4
+    abs_mag: -3.3
+    profile: {type: NFW}
+
+sagittarius:
+  default:
+    type:         dwarf
+    title:        'Sagittarius'
+    abbr:         'Sgr'
+    name:         'sagittarius'
+    color:        'BlueViolet'
+    ra:  283.83125
+    dec: -30.545278
+    distance: 26.3
+    dsigma: 2.0
+    major_axis: 342
+    ellipticity: 0.64
+    abs_mag: -13.5
+    profile: {type: NFW}
+
+sagittarius_II:
+  default:
+    type:         dwarf
+    title:        'Sagittarius II'
+    abbr:         'Sgr II'
+    name:         'sagittarius_II'
+    color:        'dodgerblue'
+    ra:  298.1647083
+    dec: -22.0650528
+    distance: 69.2
+    dsigma: 5
+    major_axis: 1.6
+    ellipticity: 0 # < 0.1
+    abs_mag: -5.2
+    profile: {type: NFW}
+
+sculptor:
+  default:
+    type:         dwarf
+    title:        'Sculptor'
+    abbr:         'Scl'
+    name:         'sculptor'
+    color:        'sienna'
+    ra:  15.0183
+    dec: -33.7186
+    distance: 83.9
+    dsigma: 6.0
+    major_axis: 11.17
+    ellipticity: 0.33
+    abs_mag: -10.82
+    profile: {type: NFW}
+
+segue_1:
+  default:
+    type:         dwarf
+    title:        'Segue 1'
+    abbr:         'Seg 1'
+    name:         'segue_1'
+    color:        'tomato'
+    ra:  151.7504
+    dec: 16.0756
+    distance: 22.9
+    dsigma: 2.0
+    major_axis: 3.62
+    ellipticity: 0.33
+    abs_mag: -1.3
+    profile: {type: NFW}
+
+segue_2:
+  default:
+    type:         dwarf
+    title:        'Segue 2'
+    abbr:         'Seg 2'
+    name:         'segue_2'
+    color:        'darkorange'
+    ra:  34.8226
+    dec: 20.1624
+    distance: 35.0
+    dsigma: 2.0
+    major_axis: 3.76
+    ellipticity: 0.22
+    abs_mag: -1.86
+    profile: {type: NFW}
+
+sextans:
+  default:
+    type:         dwarf
+    title:        'Sextans'
+    abbr:         'Sex'
+    name:         'sextans'
+    color:        'silver'
+    ra:  153.2628
+    dec: -1.6133
+    distance: 85.9
+    dsigma: 4.0
+    major_axis: 16.5
+    ellipticity: 0.3
+    abs_mag: -8.72
+    profile: {type: NFW}
+
+triangulum_II:
+  default:
+    type:         dwarf
+    title:        'Triangulum II'
+    abbr:         'Tri II'
+    name:         'triangulum_II'
+    color:        'darkblue'
+    ra:  33.3252
+    dec: 36.1702
+    distance: 30.1
+    dsigma: 2.0
+    major_axis: 1.99
+    ellipticity: 0.46
+    abs_mag: -1.6
+    profile: {type: NFW}
+
+tucana_II:
+  default:
+    type:         dwarf
+    title:        'Tucana II'
+    abbr:         'Tuc II'
+    name:         'tucana_II'
+    color:        'royalblue'
+    ra:  342.9796
+    dec: -58.5689
+    distance: 57.5
+    dsigma: 8.0
+    major_axis: 12.586
+    ellipticity: 0.39
+    abs_mag: -3.8
+    profile: {type: NFW}
+
+tucana_III:
+  default:
+    type:         dwarf
+    title:        'Tucana III'
+    abbr:         'Tuc III'
+    name:         'tucana_III'
+    color:        'red'
+    ra:  359.15
+    dec: -59.6
+    distance: 25.2
+    dsigma: 2.0
+    major_axis: 6
+    ellipticity: 0
+    abs_mag: -2.4
+    profile: {type: NFW}
+
+tucana_IV:
+  default:
+    type:         dwarf
+    title:        'Tucana IV'
+    abbr:         'Tuc IV'
+    name:         'tucana_IV'
+    color:        'green'
+    ra:  0.73
+    dec: -60.85
+    distance: 48.1
+    dsigma: 4.0
+    major_axis: 11.8
+    ellipticity: 0.4
+    abs_mag: -3.5
+    profile: {type: NFW}
+
+tucana_V:
+  default:
+    type:         dwarf
+    title:        'Tucana V'
+    abbr:         'Tuc V'
+    name:         'tucana_V'
+    color:        'blue'
+    ra:  354.35
+    dec: -63.27
+    distance: 55.2
+    dsigma: 9.0
+    major_axis: 1.8
+    ellipticity: 0.7
+    abs_mag: -1.6
+    profile: {type: NFW}
+
+ursa_major_I:
+  default:
+    type:         dwarf
+    title:        'Ursa Major I'
+    abbr:         'UMa I'
+    name:         'ursa_major_I'
+    color:        'purple'
+    ra:  158.7706
+    dec: 51.9479
+    distance: 97.3
+    dsigma: 4.0
+    major_axis: 8.31
+    ellipticity: 0.59
+    abs_mag: -5.12
+    profile: {type: NFW}
+
+ursa_major_II:
+  default:
+    type:         dwarf
+    title:        'Ursa Major II'
+    abbr:         'UMa II'
+    name:         'ursa_major_II'
+    color:        'indigo'
+    ra:  132.8726
+    dec: 63.1335
+    distance: 32.1
+    dsigma: 4.0
+    major_axis: 13.8
+    ellipticity: 0.56
+    abs_mag: -4.25
+    profile: {type: NFW}
+
+ursa_minor:
+  default:
+    type:         dwarf
+    title:        'Ursa Minor'
+    abbr:         'UMi'
+    name:         'ursa_minor'
+    color:        'red'
+    ra:  227.242
+    dec: 67.2221
+    distance: 76.2
+    dsigma: 3.0
+    major_axis: 18.3
+    ellipticity: 0.55
+    abs_mag: -9.03
+    profile: {type: NFW}
+
+virgo_I:
+  default:
+    type:         dwarf
+    title:        'Virgo I'
+    abbr:         'Vir I'
+    name:         'virgo_I'
+    color:        'cyan'
+    ra:  180.038
+    dec: -0.681
+    distance: 91.2
+    dsigma: 29.0
+    major_axis: 1.76
+    ellipticity: 0.59
+    abs_mag: -0.33
+    profile: {type: NFW}
+
+willman_1:
+  default:
+    type:         dwarf
+    title:        'Willman 1'
+    abbr:         'Wil 1'
+    name:         'willman_1'
+    color:        'cyan'
+    ra:  162.3436
+    dec: 51.0501
+    distance: 38.0
+    dsigma: 7.0
+    major_axis: 2.51
+    ellipticity: 0.47
+    abs_mag: -2.53
+    profile: {type: NFW}

--- a/dmsky/data/targets/dwarfs/defaults2020.yaml
+++ b/dmsky/data/targets/dwarfs/defaults2020.yaml
@@ -2,7 +2,7 @@
 # All dwarfs should appear in this file.
 #
 #key:
-#  default:
+#  default2020:
 #    type:         dwarf or cluster
 #    title:        full name
 #    abbr:         IAU abbreviation
@@ -18,7 +18,7 @@
 #    profile:      density profile type
 
 antlia_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Antlia II'
     abbr:         'Ant I'
@@ -34,7 +34,7 @@ antlia_II:
     profile: {type: NFW}
 
 aquarius_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Aquarius II'
     abbr:         'Aqr II'
@@ -50,7 +50,7 @@ aquarius_II:
     profile: {type: NFW}
 
 bootes_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Bootes I'
     abbr:         'Boo I'
@@ -66,7 +66,7 @@ bootes_I:
     profile: {type: NFW}
 
 bootes_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Bootes II'
     abbr:         'Boo II'
@@ -82,7 +82,7 @@ bootes_II:
     profile: {type: NFW}
 
 bootes_III:
-  default:
+  default2020:
     type:         dwarf
     title:        'Bootes III'
     abbr:         'Boo III'
@@ -98,7 +98,7 @@ bootes_III:
     profile: {type: NFW}
 
 bootes_IV:
-  default:
+  default2020:
     type:         dwarf
     title:        'Bootes IV'
     abbr:         'Boo IV'
@@ -114,7 +114,7 @@ bootes_IV:
     profile: {type: NFW}
 
 canis_major:
-  default:
+  default2020:
     type:         dwarf
     title:        'Canis Major'
     abbr:         'CMa'
@@ -130,7 +130,7 @@ canis_major:
     profile: {type: NFW}
 
 canes_venatici_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Canes Venatici I'
     abbr:         'CVn I'
@@ -146,7 +146,7 @@ canes_venatici_I:
     profile: {type: NFW}
 
 canes_venatici_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Canes Venatici II'
     abbr:         'CVn II'
@@ -162,7 +162,7 @@ canes_venatici_II:
     profile: {type: NFW}
 
 carina:
-  default:
+  default2020:
     type:         dwarf
     title:        'Carina'
     abbr:         'Car'
@@ -178,7 +178,7 @@ carina:
     profile: {type: NFW}
 
 carina_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Carina II'
     abbr:         'Car II'
@@ -194,7 +194,7 @@ carina_II:
     profile: {type: NFW}
 
 carina_III:
-  default:
+  default2020:
     type:         dwarf
     title:        'Carina III'
     abbr:         'Car III'
@@ -210,7 +210,7 @@ carina_III:
     profile: {type: NFW}
 
 centaurus_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Centarus I'
     abbr:         'Cen I'
@@ -226,7 +226,7 @@ centaurus_I:
     profile: {type: NFW}
 
 cetus_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Cetus II'
     abbr:         'Cet II'
@@ -242,7 +242,7 @@ cetus_II:
     profile: {type: NFW}
 
 cetus_III:
-  default:
+  default2020:
     type:         dwarf
     title:        'Cetus III'
     abbr:         'Cet III'
@@ -258,7 +258,7 @@ cetus_III:
     profile: {type: NFW}
 
 columba_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Columba I'
     abbr:         'Col I'
@@ -274,7 +274,7 @@ columba_I:
     profile: {type: NFW}
 
 coma_berenices:
-  default:
+  default2020:
     type:         dwarf
     title:        'Coma Berenices'
     abbr:         'Com'
@@ -290,7 +290,7 @@ coma_berenices:
     profile: {type: NFW}
 
 crater_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Crater II'
     abbr:         'Crt II'
@@ -306,7 +306,7 @@ crater_II:
     profile: {type: NFW}
 
 draco:
-  default:
+  default2020:
     type:         dwarf
     title:        'Draco'
     abbr:         'Dra'
@@ -322,7 +322,7 @@ draco:
     profile: {type: NFW}
 
 draco_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Draco II'
     abbr:         'Dra II'
@@ -338,7 +338,7 @@ draco_II:
     profile: {type: NFW}
 
 eridanus_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Eridanus II'
     abbr:         'Eri II'
@@ -354,7 +354,7 @@ eridanus_II:
     profile: {type: NFW}
 
 eridanus_III:
-  default:
+  default2020:
     type:         dwarf
     title:        'Eridanus III'
     abbr:         'Eri III'
@@ -370,7 +370,7 @@ eridanus_III:
     profile: {type: NFW}
 
 fornax:
-  default:
+  default2020:
     type:         dwarf
     title:        'Fornax'
     abbr:         'For'
@@ -386,7 +386,7 @@ fornax:
     profile: {type: NFW}
 
 grus_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Grus I'
     abbr:         'Gru I'
@@ -402,7 +402,7 @@ grus_I:
     profile: {type: NFW}
 
 grus_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Grus II'
     abbr:         'Gru II'
@@ -418,7 +418,7 @@ grus_II:
     profile: {type: NFW}
 
 hercules:
-  default:
+  default2020:
     type:         dwarf
     title:        'Hercules'
     abbr:         'Her'
@@ -434,7 +434,7 @@ hercules:
     profile: {type: NFW}
 
 horologium_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Horologium I'
     abbr:         'Hor I'
@@ -450,7 +450,7 @@ horologium_I:
     profile: {type: NFW}
 
 horologium_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Horologium II'
     abbr:         'Hor II'
@@ -466,7 +466,7 @@ horologium_II:
     profile: {type: NFW}
 
 hydra_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Hydra II'
     abbr:         'Hya II'
@@ -482,7 +482,7 @@ hydra_II:
     profile: {type: NFW}
 
 hydrus_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Hydrus I'
     abbr:         'Hyi I'
@@ -498,7 +498,7 @@ hydrus_I:
     profile: {type: NFW}
 
 indus_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Indus II'
     abbr:         'Ind II'
@@ -514,7 +514,7 @@ indus_II:
     profile: {type: NFW}
 
 kim_2:
-  default:
+  default2020:
     type:         dwarf
     title:        'Kim 2'
     abbr:         'Kim2'
@@ -530,7 +530,7 @@ kim_2:
     profile: {type: NFW}
 
 laevens_1:
-  default:
+  default2020:
     type:         dwarf
     title:        'Laevens 1'
     abbr:         'Lae 1'
@@ -546,7 +546,7 @@ laevens_1:
     profile: {type: NFW}
 
 laevens_3:
-  default:
+  default2020:
     type:         dwarf
     title:        'Laevens 3'
     abbr:         'Lae 3'
@@ -562,7 +562,7 @@ laevens_3:
     profile: {type: NFW}
 
 leo_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Leo I'
     abbr:         'Leo I'
@@ -578,7 +578,7 @@ leo_I:
     profile: {type: NFW}
 
 leo_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Leo II'
     abbr:         'Leo II'
@@ -594,7 +594,7 @@ leo_II:
     profile: {type: NFW}
 
 leo_IV:
-  default:
+  default2020:
     type:         dwarf
     title:        'Leo IV'
     abbr:         'Leo IV'
@@ -610,7 +610,7 @@ leo_IV:
     profile: {type: NFW}
 
 leo_V:
-  default:
+  default2020:
     type:         dwarf
     title:        'Leo V'
     abbr:         'Leo V'
@@ -626,7 +626,7 @@ leo_V:
     profile: {type: NFW}
 
 leo_T:
-  default:
+  default2020:
     type:         dwarf
     title:        'Leo T'
     abbr:         'Leo T'
@@ -642,7 +642,7 @@ leo_T:
     profile: {type: NFW}
 
 pegasus_III:
-  default:
+  default2020:
     type:         dwarf
     title:        'Pegasus III'
     abbr:         'Peg III'
@@ -658,7 +658,7 @@ pegasus_III:
     profile: {type: NFW}
 
 phoenix_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Phoenix II'
     abbr:         'Phe II'
@@ -674,7 +674,7 @@ phoenix_II:
     profile: {type: NFW}
 
 pictor_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Pictor I'
     abbr:         'Pic I'
@@ -690,7 +690,7 @@ pictor_I:
     profile: {type: NFW}
 
 pictor_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Pictor II'
     abbr:         'Pic II'
@@ -706,7 +706,7 @@ pictor_II:
     profile: {type: NFW}
 
 pisces_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Pisces II'
     abbr:         'Psc II'
@@ -722,7 +722,7 @@ pisces_II:
     profile: {type: NFW}
 
 reticulum_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Reticulum II'
     abbr:         'Ret II'
@@ -738,7 +738,7 @@ reticulum_II:
     profile: {type: NFW}
 
 reticulum_III:
-  default:
+  default2020:
     type:         dwarf
     title:        'Reticulum III'
     abbr:         'Ret III'
@@ -754,7 +754,7 @@ reticulum_III:
     profile: {type: NFW}
 
 sagittarius:
-  default:
+  default2020:
     type:         dwarf
     title:        'Sagittarius'
     abbr:         'Sgr'
@@ -770,7 +770,7 @@ sagittarius:
     profile: {type: NFW}
 
 sagittarius_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Sagittarius II'
     abbr:         'Sgr II'
@@ -786,7 +786,7 @@ sagittarius_II:
     profile: {type: NFW}
 
 sculptor:
-  default:
+  default2020:
     type:         dwarf
     title:        'Sculptor'
     abbr:         'Scl'
@@ -802,7 +802,7 @@ sculptor:
     profile: {type: NFW}
 
 segue_1:
-  default:
+  default2020:
     type:         dwarf
     title:        'Segue 1'
     abbr:         'Seg 1'
@@ -818,7 +818,7 @@ segue_1:
     profile: {type: NFW}
 
 segue_2:
-  default:
+  default2020:
     type:         dwarf
     title:        'Segue 2'
     abbr:         'Seg 2'
@@ -834,7 +834,7 @@ segue_2:
     profile: {type: NFW}
 
 sextans:
-  default:
+  default2020:
     type:         dwarf
     title:        'Sextans'
     abbr:         'Sex'
@@ -850,7 +850,7 @@ sextans:
     profile: {type: NFW}
 
 triangulum_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Triangulum II'
     abbr:         'Tri II'
@@ -866,7 +866,7 @@ triangulum_II:
     profile: {type: NFW}
 
 tucana_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Tucana II'
     abbr:         'Tuc II'
@@ -882,7 +882,7 @@ tucana_II:
     profile: {type: NFW}
 
 tucana_III:
-  default:
+  default2020:
     type:         dwarf
     title:        'Tucana III'
     abbr:         'Tuc III'
@@ -898,7 +898,7 @@ tucana_III:
     profile: {type: NFW}
 
 tucana_IV:
-  default:
+  default2020:
     type:         dwarf
     title:        'Tucana IV'
     abbr:         'Tuc IV'
@@ -914,7 +914,7 @@ tucana_IV:
     profile: {type: NFW}
 
 tucana_V:
-  default:
+  default2020:
     type:         dwarf
     title:        'Tucana V'
     abbr:         'Tuc V'
@@ -930,7 +930,7 @@ tucana_V:
     profile: {type: NFW}
 
 ursa_major_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Ursa Major I'
     abbr:         'UMa I'
@@ -946,7 +946,7 @@ ursa_major_I:
     profile: {type: NFW}
 
 ursa_major_II:
-  default:
+  default2020:
     type:         dwarf
     title:        'Ursa Major II'
     abbr:         'UMa II'
@@ -962,7 +962,7 @@ ursa_major_II:
     profile: {type: NFW}
 
 ursa_minor:
-  default:
+  default2020:
     type:         dwarf
     title:        'Ursa Minor'
     abbr:         'UMi'
@@ -978,7 +978,7 @@ ursa_minor:
     profile: {type: NFW}
 
 virgo_I:
-  default:
+  default2020:
     type:         dwarf
     title:        'Virgo I'
     abbr:         'Vir I'
@@ -994,7 +994,7 @@ virgo_I:
     profile: {type: NFW}
 
 willman_1:
-  default:
+  default2020:
     type:         dwarf
     title:        'Willman 1'
     abbr:         'Wil 1'

--- a/dmsky/roster.py
+++ b/dmsky/roster.py
@@ -20,32 +20,34 @@ class Roster(odict):
     for any given target.
 
     """
-    def __init__(self, *targets):
-        """C'tor
+    def __init__(self, *targets, **kwargs):
+        """Constructor.
 
         Targets can be passed either:
         1) As string elements of `targets` (looked up in target library)
         2) As object elements of `targets` (name taken from the target)
         3) As a list in args
         4) As an existing Roster
+
+        kwargs : passed to the create_target if target is a string
         """
         super(Roster, self).__init__()
-        self._parse_args(targets)
+        self._parse_args(targets,**kwargs)
 
-    def _parse_args(self, targets):
+    def _parse_args(self, targets, **kwargs):
         """Internal function to parse all the various possible
         type of inputs to the c'tor of this class
         """
         for arg in targets:
             if isinstance(arg, str):
-                target = targetlib.create_target(arg)
+                target = targetlib.create_target(arg, **kwargs)
                 self[target.name] = target
             elif isinstance(arg, Target):
                 self[arg.name] = arg
             elif isinstance(arg, Roster):
-                self._parse_args(arg.values())
+                self._parse_args(arg.values(), **kwargs)
             elif hasattr(arg, '__iter__'):
-                self._parse_args(arg)
+                self._parse_args(arg, **kwargs)
             else:
                 msg = "Unrecognized argument type: %s" % (type(arg))
                 raise ValueError(msg)
@@ -73,11 +75,11 @@ class Roster(odict):
                 raise e
 
 
-def factory(*targets):
+def factory(*targets, **kwargs):
     """Factory for creating a roster. Arguments are passed directly to
     the Roster constructor.
     """
-    return Roster(*targets)
+    return Roster(*targets, **kwargs)
 
 
 class RosterLibrary(ObjectLibrary):
@@ -123,7 +125,7 @@ class RosterLibrary(ObjectLibrary):
 
         return ret
 
-    def create_roster(self, name, *targets):
+    def create_roster(self, name, *targets, **kwargs):
         """Create a roster
 
         Parameters
@@ -144,4 +146,4 @@ class RosterLibrary(ObjectLibrary):
 
         """
         ar = self.get_roster_list(name, *targets)
-        return factory(*ar)
+        return factory(*ar, **kwargs)

--- a/dmsky/targets.py
+++ b/dmsky/targets.py
@@ -7,11 +7,11 @@ a given sky position. Classes inherit from the `Target` baseclass and
 can be created with the `factory` function.
 """
 import sys
+import copy
 from os.path import abspath, dirname, join
 from collections import OrderedDict as odict
 
 import numpy as np
-
 
 from dmsky.jcalc import LoSIntegral, LoSIntegralFast, LoSIntegralInterp
 from dmsky.utils import coords
@@ -724,11 +724,26 @@ class TargetLibrary(ObjectLibrary):
         ('path', join(dirname(abspath(__file__)), 'data', _suffix)),
     )
 
-    def get_target_dict(self, name, version=None, **kwargs):
+    def get_target_dict(self, name, version=None, default='default', **kwargs):
         """Step through the various levels of dependencies to get the
         full dictionary for a target.
 
         target: version -> ... -> target: default -> default: type
+
+        Parameters
+        ----------
+        name    : str
+            target name
+        version : str
+            version for target parameters
+        default : str
+            name of default parameters to use
+        kwargs  : dict
+            keyword arguments passed to target dict
+
+        Returns
+        -------
+        dict    : dictionary of target parameters
         """
         n, v = item_version(name)
         if version is not None and v is not None:
@@ -738,7 +753,7 @@ class TargetLibrary(ObjectLibrary):
         if v is not None:
             version = v
         if version is None:
-            version = 'default'
+            version = default
         name = n
 
         # Start with the target:version requested
@@ -748,18 +763,18 @@ class TargetLibrary(ObjectLibrary):
             msg = "Couldn't find name=%s, version=%s"%(name,version)
             raise KeyError(msg)
 
-        # Walk down the chain until we either return None or the
+        # Walk down the chain until we either return 'None' or the
         # 'default' version
         ret['version'] = version
-        while (version is not None) and (version != 'default'):
-            version = ret.get('base', 'default')
+        while (version is not None) and (version != default):
+            version = ret.get('base', default)
             ret = merge_dict(self.library[name][version], ret)
         kwargs['name'] = name
         # And finally, overwrite with kwargs
         update_dict(ret, kwargs)
-        return ret
+        return copy.deepcopy(ret)
 
-    def create_target(self, name, version=None, **kwargs):
+    def create_target(self, name, version=None, default='default', **kwargs):
         """Create a `Target`
 
         Parameters
@@ -772,14 +787,16 @@ class TargetLibrary(ObjectLibrary):
             Key that specifies which set of parameters to used
             for this target
 
+        default : str
+            Name of default parameter dictionary to use
+
         Returns
         -------
 
         target : `Target`
             The newly created Target
-
         """
-        kw = self.get_target_dict(name, version, **kwargs)
+        kw = self.get_target_dict(name, version, default, **kwargs)
         ttype = kw.pop('type')
 
         return factory(ttype, **kw)

--- a/dmsky/targets.py
+++ b/dmsky/targets.py
@@ -742,7 +742,11 @@ class TargetLibrary(ObjectLibrary):
         name = n
 
         # Start with the target:version requested
-        ret = self.library[name][version]
+        try:
+            ret = self.library[name][version]
+        except KeyError as e:
+            msg = "Couldn't find name=%s, version=%s"%(name,version)
+            raise KeyError(msg)
 
         # Walk down the chain until we either return None or the
         # 'default' version
@@ -765,7 +769,7 @@ class TargetLibrary(ObjectLibrary):
             A name for the `Target`
 
         version : str
-            Key that species which set of parameters to used
+            Key that specifies which set of parameters to used
             for this target
 
         Returns

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Generic python script.
+Test the density creation
 """
 __author__ = "Alex Drlica-Wagner"
 import os,sys

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""
+Test the creation of rosters
+"""
+__author__ = "Alex Drlica-Wagner"
+
+import numpy as np
+
+import dmsky.roster
+
+def test_create_roster():
+    # Build the library of pre-defined rosters
+    roster_library = dmsky.roster.RosterLibrary()
+
+    ackermann2015 = roster_library.create_roster('ackermann2015_dsphs')
+    assert len(ackermann2015) == 15
+    assert 'grus_II' not in ackermann2015
+
+    import pdb; pdb.set_trace()
+
+    albert2017 = roster_library.create_roster('albert2017_dsphs')
+    assert len(albert2017) == 41
+    assert 'grus_II' in albert2017
+
+    # Create test2015
+    test2015 = roster_library.create_roster('test2015')
+    assert len(test2015) == 16
+    assert 'segue_1' in test2015
+    assert 'bootes_I' in test2015
+    assert 'bootes_II' in test2015
+    assert 'grus_II' not in test2015
+
+    # Create the test with updated cooredinates from 2020
+    test2020 = roster_library.create_roster('test2015',default='default2020')
+    assert len(test2020) == 16
+
+test_create_roster()

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+Generic python script.
+"""
+__author__ = "Alex Drlica-Wagner"
+
+import numpy as np
+import dmsky.targets
+
+def test_create_target():
+    # Build the library of pre-defined rosters
+    target_library = dmsky.targets.TargetLibrary()
+
+    # Ursa Minor using implicit defaults
+    umi = target_library.create_target('ursa_minor')
+    assert umi.ra == 227.2854
+    assert umi.dec == 67.2225
+    assert umi.distance == 76.0
+
+    # Check that implicit and explicit defaults the same
+    umi2015 = target_library.create_target('ursa_minor',default='default')
+    assert umi2015.ra == umi.ra
+    assert umi2015.dec == umi.dec
+    assert umi2015.distance == umi.distance
+
+    umi2020 = target_library.create_target('ursa_minor',default='default2020')
+    assert umi2020.ra == 227.242
+    assert umi2020.dec == 67.2221
+    assert umi2020.distance == 76.2
+
+    #print(umi2020)
+
+test_create_target()


### PR DESCRIPTION
This PR is to start the process of updating the default photometric properties for the dwarfs to reflect the newest measurements collected in the 2020 dwarf census ([1912.03302](https://arxiv.org/abs/1912.03302)). The big question for this PR is how we want to deal with changing the default values. Due to the library structure, a change to the ra,dec in the defaults will propagate to each of the other rosters that depends on the defaults to set these values. This will cause an unexpected change for users who will now see slight shifts in their satellite parameters without having updated anything.

There are two possible ways to address this (though neither has been done yet):
1) We could have every new target explicitly specify `base: default2020` (the default is `base: default`). This will leave the default unchanged for the older targets.
2) We can move the old defaults to `defaults2016` and have every old target explicitly derive from `base: default2016`. 

It seems like we should probably start specifying the `base` explicitly in all new and old targets. Maybe this is a good time to make this change.