### PR TITLE
Defaults 2022

### DIFF
--- a/dmsky/data/targets/dwarfs/assorted.yaml
+++ b/dmsky/data/targets/dwarfs/assorted.yaml
@@ -1,0 +1,65 @@
+# Random assortment of J-factors
+# Sometimes from discovery/spectroscopy papers.
+
+crater_II:
+  # Table I from Boddy et al. 2020
+  # https://arxiv.org/abs/1909.13197
+  # log10(J(0.5deg)) = 15.35 [+0.27,-0.25]
+  boddy2020_nfw:
+    j_integ: 2.239e+15
+    j_sigma: 0.26
+    profile: {type: NFW}
+
+eridanus_II:
+  # Table 1 in Li et al. 2017
+  # https://arxiv.org/abs/1611.05052
+  # log10(J(0.5deg)) = 16.6 [+/-0.9]
+  li2016_nfw:
+    j_integ: 3.981e16
+    j_sigma: 0.9
+    profile: {type: NFW}
+
+hydrus_I: 
+  # Table 1 in Koposov et al. 2018
+  # https://arxiv.org/abs/1804.06430
+  # log10(J(0.5deg)) = 18.33 [+0.38,0.34]
+  koposov2018_nfw:
+    j_integ: 2.14e18
+    j_sigma: 0.36
+    profile: {type: NFW}
+  # Table I from Boddy et al. 2020
+  # https://arxiv.org/abs/1909.13197
+  # log10(J(0.5deg)) = 18.65 [+0.32,-0.31]
+  boddy2020_nfw:
+    j_integ: 4.47e18
+    j_sigma: 0.315
+    profile: {type: NFW}
+
+pegasus_IV:
+  # Table 1 from Cerny et al. 2022
+  # https://arxiv.org/abs/2203.11788
+  # log10(J(0.5deg)) = 17.9 [+/-0.8]
+  cerny2022_nfw:
+    j_integ: 7.94e17
+    j_sigma: 0.8
+    profile: {type: NFW}
+
+sagittarius_II:
+  # Table I from Boddy et al. 2020
+  # https://arxiv.org/abs/1909.13197
+  # log10(J(0.5deg)) = 17.35 [+1.36,-0.91]
+  boddy2020_nfw:
+    j_integ: 2.24e17
+    j_sigma: 1.135
+    profile: {type: NFW}
+
+tucana_IV: 
+  # Table 1 in Simon et al. 2020
+  # https://arxiv.org/abs/1911.08493
+  # log10(J(0.5deg)) = 18.4 [+0.6,-0.5]
+  # Also upper limits for Grus II and Tucana V
+  simon2020_nfw:
+    j_integ: 2.51e18
+    j_sigma: 0.55
+    profile: {type: NFW}
+

--- a/dmsky/data/targets/dwarfs/defaults2020.yaml
+++ b/dmsky/data/targets/dwarfs/defaults2020.yaml
@@ -1,4 +1,4 @@
-# Default set of dwarf characterisitcs.
+# Default set of dwarf characteristics.
 # All dwarfs should appear in this file.
 #
 #key:

--- a/dmsky/data/targets/dwarfs/defaults2022.yaml
+++ b/dmsky/data/targets/dwarfs/defaults2022.yaml
@@ -1,0 +1,1520 @@
+# Default set of dwarf characteristics.
+# All dwarfs should appear in this file.
+#
+#key:
+#  default2022:
+#    type:         dwarf or cluster
+#    title:        full name
+#    abbr:         IAU abbreviation
+#    name:         codename
+#    color:        display color
+#    ra:           right ascension (deg)
+#    dec:          declination (deg)
+#    distance:     distance (kpc)
+#    dsigma:       distance uncertainty (kpc)
+#    major_axis:   semi-major half-light radius (arcmin)
+#    ellipticity:  ellipticity
+#    abs_mag:      absolute magnitude (mag)
+#    profile:      density profile type
+
+antlia_II:
+  default2022:
+    type:         dwarf
+    title:        'Antlia II'
+    abbr:         'Ant I'
+    name:         'antlia_II'
+    color:        'blue'
+    ra:  143.8868
+    dec: -36.7673
+    distance: 131.8
+    dsigma: 6.0
+    major_axis: 76.2
+    ellipticity: 0.38
+    abs_mag: -9.03
+    profile: {type: NFW}
+
+aquarius_II:
+  default2022:
+    type:         dwarf
+    title:        'Aquarius II'
+    abbr:         'Aqr II'
+    name:         'aquarius_II'
+    color:        'cyan'
+    ra:  338.4813
+    dec: -9.3274
+    distance: 107.6
+    dsigma: 3.3
+    major_axis: 5.1
+    ellipticity: 0.39
+    abs_mag: -4.4
+    profile: {type: NFW}
+
+balbinot_1:
+  # Balbinot2013ApJ...767..101B
+  default2022:
+    type:         star_cluster
+    title:        'Balbinot 1'
+    abbr:         'Bal 1'
+    name:         'balbinot_1'
+    color:        'blue'
+    ra:  332.6798
+    dec: 14.9497
+    distance: 31.9
+    dsigma: 1.3
+    major_axis: 0.6
+    ellipticity: 0.0
+    abs_mag: -1.21
+    profile: {type: NFW}
+
+bliss_1:
+  # Mau2019ApJ...875..154M
+  default2022:
+    type:         star_cluster
+    title:        'BLISS 1'
+    abbr:         'BLS 1'
+    name:         'bliss_1'
+    color:        'blue'
+    ra:  177.51
+    dec: -41.772
+    distance: 23.7
+    dsigma: 1.45
+    major_axis: 0.6
+    ellipticity: 0.06
+    abs_mag: 0.0
+    profile: {type: NFW}
+
+bootes_I:
+  default2022:
+    type:         dwarf
+    title:        'Bootes I'
+    abbr:         'Boo I'
+    name:         'bootes_I'
+    color:        'blue'
+    ra:  210.02
+    dec: 14.5135
+    distance: 66.1
+    dsigma: 2.0
+    major_axis: 9.97
+    ellipticity: 0.3
+    abs_mag: -6.02
+    profile: {type: NFW}
+
+bootes_II:
+  default2022:
+    type:         dwarf
+    title:        'Bootes II'
+    abbr:         'Boo II'
+    name:         'bootes_II'
+    color:        'mediumblue'
+    ra:  209.5141
+    dec: 12.8553
+    distance: 41.7
+    dsigma: 1.0
+    major_axis: 3.17
+    ellipticity: 0.25
+    abs_mag: -2.94
+    profile: {type: NFW}
+
+bootes_III:
+  default2022:
+    type:         dwarf
+    title:        'Bootes III'
+    abbr:         'Boo III'
+    name:         'bootes_III'
+    color:        'darkblue'
+    ra:  209.3
+    dec: 26.8
+    distance: 46.8
+    dsigma: 2.0
+    major_axis: 30.0
+    ellipticity: 0.5
+    abs_mag: -5.75
+    profile: {type: NFW}
+
+bootes_IV:
+  default2022:
+    type:         dwarf
+    title:        'Bootes IV'
+    abbr:         'Boo IV'
+    name:         'bootes_IV'
+    color:        'darkblue'
+    ra:  233.689
+    dec: 43.726
+    distance: 208.9
+    dsigma: 19.0
+    major_axis: 7.6
+    ellipticity: 0.64
+    abs_mag: -4.53
+    profile: {type: NFW}
+
+bootes_V:
+  default2022:
+    type:         dwarf
+    title:        'Bootes V'
+    abbr:         'Boo V'
+    name:         'bootes_V'
+    color:        'darkblue'
+    ra:  213.909
+    dec: 32.914
+    distance: 102.
+    dsigma: 7.0
+    major_axis: 0.76
+    ellipticity: 0.2
+    abs_mag: -3.2
+    profile: {type: NFW}
+
+canis_major:
+  default2022:
+    type:         dwarf
+    title:        'Canis Major'
+    abbr:         'CMa'
+    name:         'canis_major'
+    color:        'SlateBlue'
+    ra:  108.1458333
+    dec: -27.66666667
+    distance: 7.2
+    dsigma: 1.0
+    major_axis: .nan
+    ellipticity: .nan
+    abs_mag: -14.39
+    profile: {type: NFW}
+
+canes_venatici_I:
+  default2022:
+    type:         dwarf
+    title:        'Canes Venatici I'
+    abbr:         'CVn I'
+    name:         'canes_venatici_I'
+    color:        'dodgerblue'
+    ra:  202.0091
+    dec: 33.5521
+    distance: 217.8
+    dsigma: 10.0
+    major_axis: 7.12
+    ellipticity: 0.44
+    abs_mag: -8.8
+    profile: {type: NFW}
+
+canes_venatici_II:
+  default2022:
+    type:         dwarf
+    title:        'Canes Venatici II'
+    abbr:         'CVn II'
+    name:         'canes_venatici_II'
+    color:        'steelblue'
+    ra:  194.2927
+    dec: 34.3226
+    distance: 160.0
+    dsigma: 4.0
+    major_axis: 1.52
+    ellipticity: 0.4
+    abs_mag: -5.17
+    profile: {type: NFW}
+
+carina:
+  default2022:
+    type:         dwarf
+    title:        'Carina'
+    abbr:         'Car'
+    name:         'carina'
+    color:        'mediumslateblue'
+    ra:  100.4065
+    dec: -50.9593
+    distance: 105.0
+    dsigma: 6.0
+    major_axis: 10.1
+    ellipticity: 0.36
+    abs_mag: -9.43
+    profile: {type: NFW}
+
+carina_II:
+  default2022:
+    type:         dwarf
+    title:        'Carina II'
+    abbr:         'Car II'
+    name:         'carina_II'
+    color:        'cyan'
+    ra:  114.1066
+    dec: -57.9991
+    distance: 36.1
+    dsigma: 0.6
+    major_axis: 8.69
+    ellipticity: 0.34
+    abs_mag: -4.5
+    profile: {type: NFW}
+
+carina_III:
+  default2022:
+    type:         dwarf
+    title:        'Carina III'
+    abbr:         'Car III'
+    name:         'carina_III'
+    color:        'cyan'
+    ra:  114.6298
+    dec: -57.8997
+    distance: 27.8
+    dsigma: 0.6
+    major_axis: 3.75
+    ellipticity: 0.55
+    abs_mag: -2.4
+    profile: {type: NFW}
+
+centaurus_I:
+  # https://arxiv.org/abs/1912.03301
+  default2022:
+    type:         dwarf
+    title:        'Centarus I'
+    abbr:         'Cen I'
+    name:         'centaurus_I'
+    color:        'cyan'
+    ra:  189.585
+    dec: -40.902
+    distance: 116.4
+    dsigma: 1.1
+    major_axis: 2.9
+    ellipticity: 0.4
+    abs_mag: -5.55
+    profile: {type: NFW}
+
+cetus_II:
+  default2022:
+    type:         dwarf
+    title:        'Cetus II'
+    abbr:         'Cet II'
+    name:         'cetus_II'
+    color:        'cyan'
+    ra:  19.47
+    dec: -17.42
+    distance: 29.9
+    dsigma: 3.0
+    major_axis: 1.9
+    ellipticity: 0.0 # < 0.4
+    abs_mag: 0.0
+    profile: {type: NFW}
+
+cetus_III:
+  default2022:
+    type:         dwarf
+    title:        'Cetus III'
+    abbr:         'Cet III'
+    name:         'cetus_III'
+    color:        'cyan'
+    ra:  31.331
+    dec: -4.27
+    distance: 251.2
+    dsigma: 17.5
+    major_axis: 1.23
+    ellipticity: 0.76
+    abs_mag: -2.5
+    profile: {type: NFW}
+
+columba_I:
+  default2022:
+    type:         dwarf
+    title:        'Columba I'
+    abbr:         'Col I'
+    name:         'columba_I'
+    color:        'gray'
+    ra:  82.86
+    dec: -28.01
+    distance: 182.8
+    dsigma: 18.0
+    major_axis: 2.2
+    ellipticity: 0.3
+    abs_mag: -4.2
+    profile: {type: NFW}
+
+coma_berenices:
+  default2022:
+    type:         dwarf
+    title:        'Coma Berenices'
+    abbr:         'Com'
+    name:         'coma_berenices'
+    color:        'green'
+    ra:  186.7454
+    dec: 23.9069
+    distance: 44.1
+    dsigma: 4.0
+    major_axis: 5.64
+    ellipticity: 0.37
+    abs_mag: -4.38
+    profile: {type: NFW}
+
+crater_II:
+  default2022:
+    type:         dwarf
+    title:        'Crater II'
+    abbr:         'Crt II'
+    name:         'crater_II'
+    color:        'cyan'
+    ra:  177.31
+    dec: -18.413
+    distance: 117.5
+    dsigma: 1.1
+    major_axis: 31.2
+    ellipticity: 0.0 # < 0.1
+    abs_mag: -8.2
+    profile: {type: NFW}
+
+delve_1:
+  # Mau2020ApJ...890..136M
+  default2022:
+    type:         star_cluster
+    title:        'DELVE 1'
+    abbr:         'DEL 1'
+    name:         'delve_1'
+    color:        'blue'
+    ra:  247.725
+    dec: -0.972
+    distance: 19.0
+    dsigma: 0.55
+    major_axis: 1.1
+    ellipticity: 0.2
+    abs_mag: -0.2
+    profile: {type: NFW}
+
+delve_2:
+  # 2021ApJ...910...18C
+  default2022:
+    type:         star_cluster
+    title:        'DELVE 2'
+    abbr:         'DEL 2'
+    name:         'delve_2'
+    color:        'blue'
+    ra:  28.772
+    dec: -68.253
+    distance: 71.0
+    dsigma: 4.0
+    major_axis: 1.04
+    ellipticity: 0.03
+    abs_mag: -2.1
+    profile: {type: NFW}
+
+delve_3:
+  # Cerny2022arXiv220912422C
+  default2022:
+    type:         star_cluster
+    title:        'DELVE 3'
+    abbr:         'DEL 3'
+    name:         'delve_3'
+    color:        'blue'
+    ra:  290.396
+    dec: -60.784
+    distance: 56.0
+    dsigma: 4.0
+    major_axis: 0.4
+    ellipticity: 0.0
+    abs_mag: -1.3
+    profile: {type: NFW}
+
+delve_4:
+  # Cerny2022arXiv220912422C
+  default2022:
+    type:         star_cluster
+    title:        'DELVE 4'
+    abbr:         'DEL 4'
+    name:         'delve_4'
+    color:        'blue'
+    ra:  230.775
+    dec: 27.395
+    distance: 45.0
+    dsigma: 4.0
+    major_axis: 0.49
+    ellipticity: 0.4
+    abs_mag: -0.2
+    profile: {type: NFW}
+
+delve_5:
+  # Cerny2022arXiv220912422C
+  default2022:
+    type:         star_cluster
+    title:        'DELVE 5'
+    abbr:         'DEL 5'
+    name:         'delve_5'
+    color:        'blue'
+    ra:  222.104
+    dec: 17.468
+    distance: 39.0
+    dsigma: 3.0
+    major_axis: 0.68
+    ellipticity: 0.2
+    abs_mag: 0.4
+    profile: {type: NFW}
+
+des_1:
+  # Conn2018ApJ...852...68C
+  default2022:
+    type:         star_cluster
+    title:        'DES 1'
+    abbr:         'DES 1'
+    name:         'des_1'
+    color:        'blue'
+    ra:  8.4992
+    dec: -49.0386
+    distance: 76.0
+    dsigma: 4.0
+    major_axis: 0.245
+    ellipticity: 0.41
+    abs_mag: -1.42
+    profile: {type: NFW}
+
+des_3:
+  # Luque2018MNRAS.478.2006L
+  default2022:
+    type:         star_cluster
+    title:        'DES 3'
+    abbr:         'DES 3'
+    name:         'des_3'
+    color:        'blue'
+    ra:  325.055
+    dec: -52.5418
+    distance: 76.2
+    dsigma: 4.25
+    major_axis: 0.28
+    ellipticity: 0.17
+    abs_mag: -2.0
+    profile: {type: NFW}
+
+des_4:
+  # Torrealba2019MNRAS.484.2181T
+  default2022:
+    type:         star_cluster
+    title:        'DES 4'
+    abbr:         'DES 4'
+    name:         'des_4'
+    color:        'blue'
+    ra:  82.095
+    dec: -61.7237
+    distance: 31.3
+    dsigma: .nan
+    major_axis: 0.83
+    ellipticity: 0.0
+    abs_mag: -1.1
+    profile: {type: NFW}
+
+des_5:
+  # Torrealba2019MNRAS.484.2181T
+  default2022:
+    type:         star_cluster
+    title:        'DES 5'
+    abbr:         'DES 5'
+    name:         'des_5'
+    color:        'blue'
+    ra:  77.5035
+    dec: -62.5805
+    distance: 24.8
+    dsigma: .nan
+    major_axis: 0.18
+    ellipticity: 0.0
+    abs_mag: 0.3
+    profile: {type: NFW}
+
+des_sgr_1:
+  # Luque2017MNRAS.468...97L
+  default2022:
+    type:         star_cluster
+    title:        'DES Sgr 1'
+    abbr:         'DES S1'
+    name:         'des_sgr_1'
+    color:        'blue'
+    ra:  17.7929
+    dec: -13.6848
+    distance: 26.5
+    dsigma: 1.3
+    major_axis: 0.3511904762
+    ellipticity: 0.27
+    abs_mag: 0.3
+    profile: {type: NFW}
+
+des_sgr_2:
+  # Luque2017MNRAS.468...97L
+  default2022:
+    type:         star_cluster
+    title:        'DES Sgr 2'
+    abbr:         'DES S2'
+    name:         'des_sgr_2'
+    color:        'blue'
+    ra:  36.4267
+    dec: 3.0695
+    distance: 23.8
+    dsigma: 0.6
+    major_axis: 1.595238095
+    ellipticity: 0.61
+    abs_mag: -1.1
+    profile: {type: NFW}
+
+draco:
+  default2022:
+    type:         dwarf
+    title:        'Draco'
+    abbr:         'Dra'
+    name:         'draco'
+    color:        'chartreuse'
+    ra:  260.0684
+    dec: 57.9185
+    distance: 75.9
+    dsigma: 6.0
+    major_axis: 9.67
+    ellipticity: 0.29
+    abs_mag: -8.71
+    profile: {type: NFW}
+
+draco_II:
+  default2022:
+    type:         dwarf
+    title:        'Draco II'
+    abbr:         'Dra II'
+    name:         'draco_II'
+    color:        'dodgerblue'
+    ra:  238.174
+    dec: 64.579
+    distance: 21.6
+    dsigma: 3.0
+    major_axis: 3.0
+    ellipticity: 0.23
+    abs_mag: -0.8
+    profile: {type: NFW}
+
+eridanus_II:
+  default2022:
+    type:         dwarf
+    title:        'Eridanus II'
+    abbr:         'Eri II'
+    name:         'eridanus_II'
+    color:        'crimson'
+    ra:  56.0925
+    dec: -43.5329
+    distance: 380.2
+    dsigma: 30.0
+    major_axis: 1.77
+    ellipticity: 0.35
+    abs_mag: -7.21
+    profile: {type: NFW}
+
+eridanus_III:
+  # Conn2018ApJ...852...68C
+  default2022:
+    type:         star_cluster
+    title:        'Eridanus III'
+    abbr:         'Eri III'
+    name:         'eridanus_III'
+    color:        'slategrey'
+    ra:  35.6952
+    dec: -52.2838
+    distance: 91.0
+    dsigma: 4.0
+    major_axis: 0.315
+    ellipticity: 0.44
+    abs_mag: -2.07
+    profile: {type: NFW}
+
+eridanus_IV:
+  # https://arxiv.org/abs/2107.09080
+  default2022:
+    type:         dwarf
+    title:        'Eridanus IV'
+    abbr:         'Eri IV'
+    name:         'eridanus_IV'
+    color:        'slategrey'
+    ra:  76.438
+    dec: -9.515
+    distance: 76.7
+    dsigma: 5.0
+    major_axis: 4.9
+    ellipticity: 0.54
+    abs_mag: -4.7
+    profile: {type: NFW}
+
+fornax:
+  default2022:
+    type:         dwarf
+    title:        'Fornax'
+    abbr:         'For'
+    name:         'fornax'
+    color:        'magenta'
+    ra:  39.9583
+    dec: -34.4997
+    distance: 147.2
+    dsigma: 12.0
+    major_axis: 19.6
+    ellipticity: 0.29
+    abs_mag: -13.46
+    profile: {type: NFW}
+
+gaia_3:
+  # Torrealba2019MNRAS.484.2181T
+  default2022:
+    type:         star_cluster
+    title:        'Gaia 3'
+    abbr:         'Gaia 3'
+    name:         'gaia_3'
+    color:        'blue'
+    ra:  95.0586
+    dec: -73.4145
+    distance: 48.4
+    dsigma: .nan
+    major_axis: 0.53
+    ellipticity: 0.0
+    abs_mag: -3.3
+    profile: {type: NFW}
+
+grus_I:
+  default2022:
+    type:         dwarf
+    title:        'Grus I'
+    abbr:         'Gru I'
+    name:         'grus_I'
+    color:        'purple'
+    ra:  344.1797
+    dec: -50.18
+    distance: 120.2
+    dsigma: 12.0
+    major_axis: 0.81
+    ellipticity: 0.45
+    abs_mag: -3.47
+    profile: {type: NFW}
+
+grus_II:
+  default2022:
+    type:         dwarf
+    title:        'Grus II'
+    abbr:         'Gru II'
+    name:         'grus_II'
+    color:        'magenta'
+    ra:  331.02
+    dec: -46.44
+    distance: 53.0
+    dsigma: 5.0
+    major_axis: 6.0
+    ellipticity: 0.0 # < 0.2
+    abs_mag: -3.9
+    profile: {type: NFW}
+
+hercules:
+  default2022:
+    type:         dwarf
+    title:        'Hercules'
+    abbr:         'Her'
+    name:         'hercules'
+    color:        'orchid'
+    ra:  247.7722
+    dec: 12.7852
+    distance: 131.8
+    dsigma: 12.0
+    major_axis: 5.63
+    ellipticity: 0.69
+    abs_mag: -5.83
+    profile: {type: NFW}
+
+horologium_I:
+  default2022:
+    type:         dwarf
+    title:        'Horologium I'
+    abbr:         'Hor I'
+    name:         'horologium_I'
+    color:        'tan'
+    ra:  43.8813
+    dec: -54.116
+    distance: 79.0
+    dsigma: 8.0
+    major_axis: 1.59
+    ellipticity: 0.27
+    abs_mag: -3.55
+    profile: {type: NFW}
+
+horologium_II:
+  default2022:
+    type:         dwarf
+    title:        'Horologium II'
+    abbr:         'Hor II'
+    name:         'horologium_II'
+    color:        'gold'
+    ra:  49.1077
+    dec: -50.0486
+    distance: 78.0
+    dsigma: 8.0
+    major_axis: 2.09
+    ellipticity: 0.52
+    abs_mag: -2.6
+    profile: {type: NFW}
+
+hsc_1:
+  # Homma2019PASJ...71...94H
+  default2022:
+    type:         star_cluster
+    title:        'HSC 1'
+    abbr:         'HSC 1'
+    name:         'hsc_1'
+    color:        'blue'
+    ra:  334.309
+    dec: 3.48
+    distance: 46.0
+    dsigma: 4.0
+    major_axis: 0.44
+    ellipticity: 0.46
+    abs_mag: -0.2
+    profile: {type: NFW}
+
+hydra_II:
+  default2022:
+    type:         dwarf
+    title:        'Hydra II'
+    abbr:         'Hya II'
+    name:         'hydra_II'
+    color:        'dodgerblue'
+    ra:  185.4251
+    dec: -31.986
+    distance: 150.7
+    dsigma: 10.0
+    major_axis: 1.52
+    ellipticity: 0.24
+    abs_mag: -4.6
+    profile: {type: NFW}
+
+hydrus_I:
+  default2022:
+    type:         dwarf
+    title:        'Hydrus I'
+    abbr:         'Hyi I'
+    name:         'hydrus_I'
+    color:        'cyan'
+    ra:  37.389
+    dec: -79.3089
+    distance: 27.5
+    dsigma: 0.5
+    major_axis: 7.42
+    ellipticity: 0.21
+    abs_mag: -4.71
+    profile: {type: NFW}
+
+indus_II:
+  default2022:
+    type:         dwarf
+    title:        'Indus II'
+    abbr:         'Ind II'
+    name:         'indus_II'
+    color:        'indigo'
+    ra:  309.72
+    dec: -46.16
+    distance: 213.8
+    dsigma: 16.0
+    major_axis: 2.9
+    ellipticity: 0.0 # < 0.4
+    abs_mag: -4.3
+    profile: {type: NFW}
+
+kim_1:
+  # Kim2015ApJ...799...73K
+  default2022:
+    type:         star_cluster
+    title:        'Kim 1'
+    abbr:         'Kim 1'
+    name:         'kim_1'
+    color:        'blue'
+    ra:  332.9214
+    dec: 7.0271
+    distance: 19.8
+    dsigma: 0.9
+    major_axis: 1.2
+    ellipticity: 0.42
+    abs_mag: 0.3
+    profile: {type: NFW}
+
+kim_2:
+  default2022:
+    type:         star_cluster
+    title:        'Kim 2'
+    abbr:         'Kim 2'
+    name:         'kim_2'
+    color:        'indianred'
+    ra:  317.202
+    dec: -51.1671
+    distance: 100.0
+    dsigma: 7.0
+    major_axis: 0.48
+    ellipticity: 0.32
+    abs_mag: -3.32
+    profile: {type: NFW}
+
+kim_3:
+  # Kim2016ApJ...820..119K
+  default2022:
+    type:         star_cluster
+    title:        'Kim 3'
+    abbr:         'Kim 3'
+    name:         'kim_3'
+    color:        'blue'
+    ra:  200.688
+    dec: -30.6
+    distance: 15.14
+    dsigma: 0.64
+    major_axis: 0.52
+    ellipticity: 0.17
+    abs_mag: 0.7
+    profile: {type: NFW}
+
+koposov_1:
+  # Munoz2018ApJ...860...66M
+  default2022:
+    type:         star_cluster
+    title:        'Koposov 1'
+    abbr:         'Kop 1'
+    name:         'koposov_1'
+    color:        'blue'
+    ra:  179.8253
+    dec: 12.2615
+    distance: 48.3
+    dsigma: .nan
+    major_axis: 0.62
+    ellipticity: 0.45
+    abs_mag: -1.04
+    profile: {type: NFW}
+
+koposov_2:
+  # Munoz2018ApJ...860...66M
+  default2022:
+    type:         star_cluster
+    title:        'Koposov 2'
+    abbr:         'Kop 2'
+    name:         'koposov_2'
+    color:        'blue'
+    ra:  119.5715
+    dec: 26.2574
+    distance: 34.7
+    dsigma: .nan
+    major_axis: 0.44
+    ellipticity: 0.43
+    abs_mag: -0.92
+    profile: {type: NFW}
+
+laevens_1:
+  default2022:
+    type:         dwarf
+    title:        'Laevens 1'
+    abbr:         'Lae 1'
+    name:         'laevens_1'
+    color:        'dodgerblue'
+    ra:  174.0668
+    dec: -10.8772
+    distance: 145.0
+    dsigma: 17.0
+    major_axis: 0.51
+    ellipticity: 0.17
+    abs_mag: -4.8
+    profile: {type: NFW}
+
+laevens_3:
+  #  Longeard2019MNRAS.490.1498L
+  default2022:
+    type:         star_cluster
+    title:        'Laevens 3'
+    abbr:         'Lae 3'
+    name:         'laevens_3'
+    color:        'blue'
+    ra:  316.7294
+    dec: 14.98439985
+    distance: 61.4
+    dsigma: 1.1
+    major_axis: 0.64
+    ellipticity: 0.11
+    abs_mag: -2.8
+    profile: {type: NFW}
+
+leo_I:
+  default2022:
+    type:         dwarf
+    title:        'Leo I'
+    abbr:         'Leo I'
+    name:         'leo_I'
+    color:        'gold'
+    ra:  152.1146
+    dec: 12.3059
+    distance: 254.0
+    dsigma: 15.0
+    major_axis: 3.65
+    ellipticity: 0.3
+    abs_mag: -11.78
+    profile: {type: NFW}
+
+leo_II:
+  default2022:
+    type:         dwarf
+    title:        'Leo II'
+    abbr:         'Leo II'
+    name:         'leo_II'
+    color:        'goldenrod'
+    ra:  168.3627
+    dec: 22.1529
+    distance: 233.3
+    dsigma: 14.0
+    major_axis: 2.52
+    ellipticity: 0.07
+    abs_mag: -9.74
+    profile: {type: NFW}
+
+leo_IV:
+  default2022:
+    type:         dwarf
+    title:        'Leo IV'
+    abbr:         'Leo IV'
+    name:         'leo_IV'
+    color:        '#C58917'
+    ra:  173.2405
+    dec: -0.5453
+    distance: 154.2
+    dsigma: 6.0
+    major_axis: 2.54
+    ellipticity: 0.17
+    abs_mag: -4.99
+    profile: {type: NFW}
+
+leo_V:
+  default2022:
+    type:         dwarf
+    title:        'Leo V'
+    abbr:         'Leo V'
+    name:         'leo_V'
+    color:        'Peru'
+    ra:  172.7857
+    dec: 2.2194
+    distance: 177.8
+    dsigma: 10.0
+    major_axis: 1.0
+    ellipticity: 0.43
+    abs_mag: -4.4
+    profile: {type: NFW}
+
+leo_T:
+  default2022:
+    type:         dwarf
+    title:        'Leo T'
+    abbr:         'Leo T'
+    name:         'leo_T'
+    color:        'gold2'
+    ra: 143.7225
+    dec: 17.05139
+    distance: 417.0
+    dsigma: 19.
+    major_axis: 0.99
+    ellipticity: 0.0
+    abs_mag: -8.0
+    profile: {type: NFW}
+
+leo_minor_I:
+  default2022:
+    type:         dwarf
+    title:        'Leo Minor I'
+    abbr:         'LMi I'
+    name:         'leo_minor_I'
+    color:        'gold'
+    ra:  164.261
+    dec: 28.875
+    distance: 82.0
+    dsigma: 5.5
+    major_axis: 1.09
+    ellipticity: 0.0
+    abs_mag: -2.4
+    profile: {type: NFW}
+
+munoz_1:
+  # Munoz2012ApJ...753L..15M
+  default2022:
+    type:         star_cluster
+    title:        'Munoz 1'
+    abbr:         'Mun 1'
+    name:         'munoz_1'
+    color:        'blue'
+    ra:  225.449
+    dec: 66.9682
+    distance: 45.0
+    dsigma: 5.0
+    major_axis: 0.49
+    ellipticity: 0.0
+    abs_mag: -0.4
+    profile: {type: NFW}
+
+pegasus_III:
+  default2022:
+    type:         dwarf
+    title:        'Pegasus III'
+    abbr:         'Peg III'
+    name:         'pegasus_III'
+    color:        'black'
+    ra:  336.102
+    dec: 5.405
+    distance: 214.8
+    dsigma: 20.0
+    major_axis: 0.85
+    ellipticity: 0.38
+    abs_mag: -3.4
+    profile: {type: NFW}
+
+pegasus_IV:
+  # https://arxiv.org/abs/2203.11788
+  default2022:
+    type:         dwarf
+    title:        'Pegasus IV'
+    abbr:         'Peg IV'
+    name:         'pegasus_IV'
+    color:        'black'
+    ra:  328.539
+    dec: 26.620
+    distance: 90.
+    dsigma: 5.0
+    major_axis: 1.6
+    ellipticity: 0.0
+    abs_mag: -4.25
+    profile: {type: NFW}
+
+phoenix_II:
+  default2022:
+    type:         dwarf
+    title:        'Phoenix II'
+    abbr:         'Phe II'
+    name:         'phoenix_II'
+    color:        'indigo'
+    ra:  354.996
+    dec: -54.4115
+    distance: 83.0
+    dsigma: 10.0
+    major_axis: 1.49
+    ellipticity: 0.67
+    abs_mag: -3.3
+    profile: {type: NFW}
+
+pictor_I:
+  default2022:
+    type:         dwarf
+    title:        'Pictor I'
+    abbr:         'Pic I'
+    name:         'pictor_I'
+    color:        'saddlebrown'
+    ra:  70.949
+    dec: -50.2854
+    distance: 113.8
+    dsigma: 12.0
+    major_axis: 0.88
+    ellipticity: 0.63
+    abs_mag: -3.45
+    profile: {type: NFW}
+
+pictor_II:
+  default2022:
+    type:         dwarf
+    title:        'Pictor II'
+    abbr:         'Pic II'
+    name:         'pictor_II'
+    color:        'cyan'
+    ra:  101.18
+    dec: -59.897
+    distance: 45.7
+    dsigma: 5.0
+    major_axis: 3.8
+    ellipticity: 0.13
+    abs_mag: -3.2
+    profile: {type: NFW}
+
+pisces_II:
+  default2022:
+    type:         dwarf
+    title:        'Pisces II'
+    abbr:         'Psc II'
+    name:         'pisces_II'
+    color:        'chocolate'
+    ra:  344.6345
+    dec: 5.9526
+    distance: 182.0
+    dsigma: .nan
+    major_axis: 1.12
+    ellipticity: 0.34
+    abs_mag: -4.22
+    profile: {type: NFW}
+
+ps1_1:
+  # Torrealba2019MNRAS.484.2181T
+  default2022:
+    type:         star_cluster
+    title:        'PS1 1'
+    abbr:         'PS1 1'
+    name:         'ps1_1'
+    color:        'blue'
+    ra:  289.1712
+    dec: -27.8272
+    distance: 29.6
+    dsigma: .nan
+    major_axis: 0.55
+    ellipticity: 0.0
+    abs_mag: -1.9
+    profile: {type: NFW}
+
+reticulum_II:
+  default2022:
+    type:         dwarf
+    title:        'Reticulum II'
+    abbr:         'Ret II'
+    name:         'reticulum_II'
+    color:        'violet'
+    ra:  53.9203
+    dec: -54.0513
+    distance: 30.2
+    dsigma: 3.0
+    major_axis: 5.52
+    ellipticity: 0.58
+    abs_mag: -3.88
+    profile: {type: NFW}
+
+reticulum_III:
+  default2022:
+    type:         dwarf
+    title:        'Reticulum III'
+    abbr:         'Ret III'
+    name:         'reticulum_III'
+    color:        'red'
+    ra:  56.36
+    dec: -60.45
+    distance: 91.6
+    dsigma: 13.0
+    major_axis: 2.4
+    ellipticity: 0.0 # < 0.4
+    abs_mag: -3.3
+    profile: {type: NFW}
+
+sagittarius:
+  default2022:
+    type:         dwarf
+    title:        'Sagittarius'
+    abbr:         'Sgr'
+    name:         'sagittarius'
+    color:        'BlueViolet'
+    ra:  283.83125
+    dec: -30.545278
+    distance: 26.3
+    dsigma: 2.0
+    major_axis: 342.
+    ellipticity: 0.64
+    abs_mag: -13.5
+    profile: {type: NFW}
+
+sagittarius_II:
+  default2022:
+    type:         dwarf
+    title:        'Sagittarius II'
+    abbr:         'Sgr II'
+    name:         'sagittarius_II'
+    color:        'dodgerblue'
+    ra:  298.1647083
+    dec: -22.0650528
+    distance: 69.2
+    dsigma: 5.0
+    major_axis: 1.6
+    ellipticity: 0.0 # < 0.1
+    abs_mag: -5.2
+    profile: {type: NFW}
+
+sculptor:
+  default2022:
+    type:         dwarf
+    title:        'Sculptor'
+    abbr:         'Scl'
+    name:         'sculptor'
+    color:        'sienna'
+    ra:  15.0183
+    dec: -33.7186
+    distance: 83.9
+    dsigma: 6.0
+    major_axis: 11.17
+    ellipticity: 0.33
+    abs_mag: -10.82
+    profile: {type: NFW}
+
+segue_1:
+  default2022:
+    type:         dwarf
+    title:        'Segue 1'
+    abbr:         'Seg 1'
+    name:         'segue_1'
+    color:        'tomato'
+    ra:  151.7504
+    dec: 16.0756
+    distance: 22.9
+    dsigma: 2.0
+    major_axis: 3.62
+    ellipticity: 0.33
+    abs_mag: -1.3
+    profile: {type: NFW}
+
+segue_2:
+  default2022:
+    type:         dwarf
+    title:        'Segue 2'
+    abbr:         'Seg 2'
+    name:         'segue_2'
+    color:        'darkorange'
+    ra:  34.8226
+    dec: 20.1624
+    distance: 35.0
+    dsigma: 2.0
+    major_axis: 3.76
+    ellipticity: 0.22
+    abs_mag: -1.86
+    profile: {type: NFW}
+
+segue_3:
+  # Fadely2011AJ....142...88F
+  default2022:
+    type:         star_cluster
+    title:        'Segue 3'
+    abbr:         'Seg 3'
+    name:         'segue_3'
+    color:        'blue'
+    ra:  320.3795
+    dec: 19.1178
+    distance: 27.03958364
+    dsigma: .nan
+    major_axis: 0.47
+    ellipticity: 0.24
+    abs_mag: -0.06
+    profile: {type: NFW}
+
+sextans:
+  default2022:
+    type:         dwarf
+    title:        'Sextans'
+    abbr:         'Sex'
+    name:         'sextans'
+    color:        'silver'
+    ra:  153.2628
+    dec: -1.6133
+    distance: 85.9
+    dsigma: 4.0
+    major_axis: 16.5
+    ellipticity: 0.3
+    abs_mag: -8.72
+    profile: {type: NFW}
+
+smash_1:
+  # Martin2016ApJ...830L..10M
+  default2022:
+    type:         star_cluster
+    title:        'SMASH 1'
+    abbr:         'SMA 1'
+    name:         'smash_1'
+    color:        'blue'
+    ra:  95.2496
+    dec: -80.3966
+    distance: 57.0
+    dsigma: .nan
+    major_axis: 0.57
+    ellipticity: 0.62
+    abs_mag: -1.0
+    profile: {type: NFW}
+
+torrealba_1:
+  # Torrealba2019MNRAS.484.2181T
+  default2022:
+    type:         star_cluster
+    title:        'Torrealba 1'
+    abbr:         'To 1'
+    name:         'torrealba_1'
+    color:        'blue'
+    ra:  56.0826
+    dec: -69.4226
+    distance: 43.6
+    dsigma: .nan
+    major_axis: 0.27
+    ellipticity: 0.0
+    abs_mag: -1.6
+    profile: {type: NFW}
+
+triangulum_II:
+  default2022:
+    type:         dwarf
+    title:        'Triangulum II'
+    abbr:         'Tri II'
+    name:         'triangulum_II'
+    color:        'darkblue'
+    ra:  33.3252
+    dec: 36.1702
+    distance: 30.1
+    dsigma: 2.0
+    major_axis: 1.99
+    ellipticity: 0.46
+    abs_mag: -1.6
+    profile: {type: NFW}
+
+tucana_II:
+  default2022:
+    type:         dwarf
+    title:        'Tucana II'
+    abbr:         'Tuc II'
+    name:         'tucana_II'
+    color:        'royalblue'
+    ra:  342.9796
+    dec: -58.5689
+    distance: 57.5
+    dsigma: 8.0
+    major_axis: 12.586
+    ellipticity: 0.39
+    abs_mag: -3.8
+    profile: {type: NFW}
+
+tucana_III:
+  default2022:
+    type:         dwarf
+    title:        'Tucana III'
+    abbr:         'Tuc III'
+    name:         'tucana_III'
+    color:        'red'
+    ra:  359.15
+    dec: -59.6
+    distance: 25.2
+    dsigma: 2.0
+    major_axis: 6.
+    ellipticity: 0.
+    abs_mag: -2.4
+    profile: {type: NFW}
+
+tucana_IV:
+  default2022:
+    type:         dwarf
+    title:        'Tucana IV'
+    abbr:         'Tuc IV'
+    name:         'tucana_IV'
+    color:        'green'
+    ra:  0.73
+    dec: -60.85
+    distance: 48.1
+    dsigma: 4.0
+    major_axis: 11.8
+    ellipticity: 0.4
+    abs_mag: -3.5
+    profile: {type: NFW}
+
+tucana_V:
+  default2022:
+    type:         dwarf
+    title:        'Tucana V'
+    abbr:         'Tuc V'
+    name:         'tucana_V'
+    color:        'blue'
+    ra:  354.35
+    dec: -63.27
+    distance: 55.2
+    dsigma: 9.0
+    major_axis: 1.8
+    ellipticity: 0.7
+    abs_mag: -1.6
+    profile: {type: NFW}
+
+ursa_major_I:
+  default2022:
+    type:         dwarf
+    title:        'Ursa Major I'
+    abbr:         'UMa I'
+    name:         'ursa_major_I'
+    color:        'purple'
+    ra:  158.7706
+    dec: 51.9479
+    distance: 97.3
+    dsigma: 4.0
+    major_axis: 8.31
+    ellipticity: 0.59
+    abs_mag: -5.12
+    profile: {type: NFW}
+
+ursa_major_II:
+  default2022:
+    type:         dwarf
+    title:        'Ursa Major II'
+    abbr:         'UMa II'
+    name:         'ursa_major_II'
+    color:        'indigo'
+    ra:  132.8726
+    dec: 63.1335
+    distance: 32.1
+    dsigma: 4.0
+    major_axis: 13.8
+    ellipticity: 0.56
+    abs_mag: -4.25
+    profile: {type: NFW}
+
+ursa_minor:
+  default2022:
+    type:         dwarf
+    title:        'Ursa Minor'
+    abbr:         'UMi'
+    name:         'ursa_minor'
+    color:        'red'
+    ra:  227.242
+    dec: 67.2221
+    distance: 76.2
+    dsigma: 3.0
+    major_axis: 18.3
+    ellipticity: 0.55
+    abs_mag: -9.03
+    profile: {type: NFW}
+
+virgo_I:
+  default2022:
+    type:         dwarf
+    title:        'Virgo I'
+    abbr:         'Vir I'
+    name:         'virgo_I'
+    color:        'cyan'
+    ra:  180.038
+    dec: -0.681
+    distance: 91.2
+    dsigma: 29.0
+    major_axis: 1.76
+    ellipticity: 0.59
+    abs_mag: -0.33
+    profile: {type: NFW}
+
+virgo_II:
+  default2022:
+    type:         dwarf
+    title:        'Virgo II'
+    abbr:         'Vir II'
+    name:         'virgo_II'
+    color:        'cyan'
+    ra:  225.059
+    dec: 5.909
+    distance: 72.0
+    dsigma: 7.5
+    major_axis: 0.74
+    ellipticity: 0.0
+    abs_mag: -1.6
+    profile: {type: NFW}
+
+willman_1:
+  default2022:
+    type:         dwarf
+    title:        'Willman 1'
+    abbr:         'Wil 1'
+    name:         'willman_1'
+    color:        'cyan'
+    ra:  162.3436
+    dec: 51.0501
+    distance: 38.0
+    dsigma: 7.0
+    major_axis: 2.51
+    ellipticity: 0.47
+    abs_mag: -2.53
+    profile: {type: NFW}
+
+ymca_1:
+  # Gatto2021RNAAS...5..159G
+  default2022:
+    type:         star_cluster
+    title:        'YMCA 1'
+    abbr:         'YMCA 1'
+    name:         'ymca_1'
+    color:        'blue'
+    ra:  110.8369
+    dec: -64.8313
+    distance: 105.0
+    dsigma: .nan
+    major_axis: 0.165
+    ellipticity: 0 # .nan
+    abs_mag: -2.8
+    profile: {type: NFW}

--- a/dmsky/data/targets/dwarfs/pace2018v1.yaml
+++ b/dmsky/data/targets/dwarfs/pace2018v1.yaml
@@ -3,7 +3,7 @@
 # Values have been taken from Table 2 and Table A1
 # Note that equation and values are updated in published version (v2)
 
-# Photoj comes from Eq. 14 using input from Table A1
+# Photoj comes from Eq. 12 using input from Table A1
 # Lv = 10**( (Mv - 4.83)/-2.5 ) Lsun
 # photoj = 10^17.93 * ( Lv/1e4 Lsun)^0.32 * (d/100 kpc)^-2 * (rhalf/100 pc)^-1
 

--- a/dmsky/data/targets/dwarfs/pace2018v1.yaml
+++ b/dmsky/data/targets/dwarfs/pace2018v1.yaml
@@ -1,12 +1,18 @@
 # Dwarf characterisitcs from:
 # Pace & Strigari (2018) (arXiv:1802.06811v1)
 # Values have been taken from Table 2 and Table A1
-# $Format:%d$
+# Note that equation and values are updated in published version (v2)
 
-# Photoj comes from Eq. 12 using input from Table A1
+# Photoj comes from Eq. 14 using input from Table A1
 # Lv = 10**( (Mv - 4.83)/-2.5 ) Lsun
 # photoj = 10^17.93 * ( Lv/1e4 Lsun)^0.32 * (d/100 kpc)^-2 * (rhalf/100 pc)^-1
 
+antlia_II:
+  # Derived from above
+  pace2018_photoj_nfw:
+    j_integ: 4.68e+17
+    j_sigma: .nan
+    profile: {type: NFW}
 aquarius_II:
   pace2018_nfw:
     j_integ: 1.86e+18

--- a/dmsky/data/targets/dwarfs/pace2019.yaml
+++ b/dmsky/data/targets/dwarfs/pace2019.yaml
@@ -1,0 +1,587 @@
+# Dwarf J-factors from:
+# Pace & Strigari (2018) (arXiv:1802.06811v2)
+#
+# Kinematic J-factors come from Table A2.
+# Photometric J-factors come from Table 2 or Eq. 14 using input from Table A1
+#
+# Equation 14:
+# Lv = 10**( (Mv - 4.83) / -2.5 ) Lsun
+# photoj = 10^18.17 * ( Lv / 1e4 Lsun)^0.23 * (d/100 kpc)^-2 * (rhalf/100 pc)^-1
+
+and_I:
+  pace2019_nfw:
+    j_integ: 6.46E+16
+    j_sigma: 0.380
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 3.80E+16
+    j_sigma: .nan
+    profile: {type: NFW}
+
+and_III:
+  pace2019_nfw:
+    j_integ: 1.07E+17
+    j_sigma: 0.315
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 4.35E+16
+    j_sigma: .nan
+    profile: {type: NFW}
+
+and_V:
+  pace2019_nfw:
+    j_integ: 1.55E+17
+    j_sigma: 0.270
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 3.76E+16
+    j_sigma: .nan
+    profile: {type: NFW}
+
+and_VII:
+  pace2019_nfw:
+    j_integ: 9.55E+16
+    j_sigma: 0.155
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 4.21E+16
+    j_sigma: .nan
+    profile: {type: NFW}
+
+and_XIV:
+  pace2019_nfw:
+    j_integ: 5.50E+15
+    j_sigma: 0.375
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 2.77E+16
+    j_sigma: .nan
+    profile: {type: NFW}
+
+and_XVIII:
+  pace2019_nfw:
+    j_integ: 5.62E+16
+    j_sigma: 0.460
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.46E+16
+    j_sigma: .nan
+    profile: {type: NFW}
+
+aquarius_II:
+  pace2019_nfw:
+    j_integ: 1.86E+18
+    j_sigma: 0.620
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 9.65E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+bootes_I:
+  pace2019_nfw:
+    j_integ: 1.48E+18
+    j_sigma: 0.300
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 3.15E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+canes_venatici_I:
+  pace2019_nfw:
+    j_integ: 2.63E+17
+    j_sigma: 0.160
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 3.37E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+canes_venatici_II:
+  pace2019_nfw:
+    j_integ: 6.61E+17
+    j_sigma: 0.470
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 6.21E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+carina:
+  pace2019_nfw:
+    j_integ: 6.76E+17
+    j_sigma: 0.095
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.94E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+carina_II:
+  pace2019_nfw:
+    j_integ: 1.78E+18
+    j_sigma: 0.545
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.02E+19
+    j_sigma: .nan
+    profile: {type: NFW}
+
+cetus:
+  pace2019_nfw:
+    j_integ: 1.91E+16
+    j_sigma: 0.195
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 3.10E+16
+    j_sigma: .nan
+    profile: {type: NFW}
+
+cetus_II:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.26E+19
+    j_sigma: .nan
+    profile: {type: NFW}
+
+cetus_III:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 2.00E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+columba_I:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 3.98E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+coma_berenices:
+  pace2019_nfw:
+    j_integ: 1.00E+19
+    j_sigma: 0.355
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 8.49E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+draco:
+  pace2019_nfw:
+    j_integ: 6.76E+18
+    j_sigma: 0.120
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 4.05E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+draco_II:
+  pace2019_nfw:
+    j_integ: 8.51E+18
+    j_sigma: 1.545
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 6.60E+19
+    j_sigma: .nan
+    profile: {type: NFW}
+
+eridanus_II:
+  pace2019_nfw:
+    j_integ: 1.91E+17
+    j_sigma: 0.325
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.25E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+fornax:
+  pace2019_nfw:
+    j_integ: 1.23E+18
+    j_sigma: 0.100
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.59E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+grus_I:
+  pace2019_nfw:
+    j_integ: 7.59E+16
+    j_sigma: 1.585
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 9.76E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+grus_II:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    # Correcting typo...
+    #j_integ: 2.51E+18
+    j_integ: 4.17E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+hercules:
+  pace2019_nfw:
+    j_integ: 2.34E+17
+    j_sigma: 0.530
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.16E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+horologium_I:
+  pace2019_nfw:
+    j_integ: 6.17E+18
+    j_sigma: 0.880
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.73E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_kop_nfw:
+    j_integ: 1.86E+19
+    j_sigma: 0.740
+    profile: {type: NFW}
+  pace2019_photoj_kop_nfw:
+    j_integ: 2.88E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+horologium_II:
+  # Fixed Lv = 9.4e2, Mv = -2.6
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 2.51E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+hydra_II:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 7.59E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+indus_II:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 2.00E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+leo_I:
+  pace2019_nfw:
+    j_integ: 4.37E+17
+    j_sigma: 0.130
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 5.52E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+leo_II:
+  pace2019_nfw:
+    j_integ: 5.75E+17
+    j_sigma: 0.200
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 5.90E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+leo_IV:
+  pace2019_nfw:
+    j_integ: 2.51E+16
+    j_sigma: 1.080
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 5.61E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+leo_T:
+  pace2019_nfw:
+    j_integ: 3.09E+17
+    j_sigma: 0.470
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.13E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+leo_V:
+  pace2019_nfw:
+    j_integ: 4.47E+17
+    j_sigma: 0.970
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 7.19E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+pegasus_III:
+  pace2019_nfw:
+    j_integ: 2.00E+18
+    j_sigma: 0.930
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 3.62E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+phoenix_II:
+  # Fixed Lv = 2.6e3, Mv = -3.7
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 2.00E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+pictor_I:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.00E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+pictor_II:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 7.94E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+pisces_II:
+  pace2019_nfw:
+    j_integ: 2.00E+17
+    j_sigma: 1.045
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 5.08E+17
+    j_sigma: .nan
+    profile: {type: NFW}
+
+reticulum_II:
+  pace2019_nfw:
+    j_integ: 7.59E+18
+    j_sigma: 0.380
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.78E+19
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_kop_nfw:
+    j_integ: 9.12E+18
+    j_sigma: 0.375
+    profile: {type: NFW}
+  pace2019_photoj_kop_nfw:
+    j_integ: 1.72E+19
+    j_sigma: .nan
+    profile: {type: NFW}
+
+reticulum_III:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.58E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+sagittarius_II:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 6.31E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+sculptor:
+  pace2019_nfw:
+    j_integ: 3.80E+18
+    j_sigma: 0.050
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 4.88E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+segue_1:
+  pace2019_nfw:
+    j_integ: 1.32E+19
+    j_sigma: 0.535
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 2.80E+19
+    j_sigma: .nan
+    profile: {type: NFW}
+
+segue_2:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.12E+19
+    j_sigma: .nan
+    profile: {type: NFW}
+
+sextans:
+  pace2019_nfw:
+    j_integ: 5.37E+17
+    j_sigma: 0.125
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.74E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+triangulum_II:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.52E+19
+    j_sigma: .nan
+    profile: {type: NFW}
+
+tucana_II:
+  pace2019_nfw:
+    j_integ: 1.05E+19
+    j_sigma: 0.555
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 3.19E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_kop_nfw:
+    j_integ: 6.92E+18
+    j_sigma: 0.525
+    profile: {type: NFW}
+  pace2019_photoj_kop_nfw:
+    j_integ: 2.63E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+tucana_III:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 2.01E+19
+    j_sigma: .nan
+    profile: {type: NFW}
+
+tucana_IV:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 5.01E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+tucana_V:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 7.94E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+ursa_major_I:
+  pace2019_nfw:
+    j_integ: 1.82E+18
+    j_sigma: 0.280
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.19E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+ursa_major_II:
+  pace2019_nfw:
+    j_integ: 2.75E+19
+    j_sigma: 0.400
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.01E+19
+    j_sigma: .nan
+    profile: {type: NFW}
+
+ursa_minor:
+  pace2019_nfw:
+    j_integ: 5.62E+18
+    j_sigma: 0.120
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 3.37E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+virgo_I:
+  pace2019_nfw:
+    j_integ: .nan
+    j_sigma: .nan
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.26E+18
+    j_sigma: .nan
+    profile: {type: NFW}
+
+willman_1:
+  pace2019_nfw:
+    j_integ: 3.39E+19
+    j_sigma: 0.500
+    profile: {type: NFW}
+  pace2019_photoj_nfw:
+    j_integ: 1.43E+19
+    j_sigma: .nan
+    profile: {type: NFW}

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Test the creation of rosters
+Test the creation of rosters.
 """
 __author__ = "Alex Drlica-Wagner"
 
@@ -15,8 +15,6 @@ def test_create_roster():
     ackermann2015 = roster_library.create_roster('ackermann2015_dsphs')
     assert len(ackermann2015) == 15
     assert 'grus_II' not in ackermann2015
-
-    import pdb; pdb.set_trace()
 
     albert2017 = roster_library.create_roster('albert2017_dsphs')
     assert len(albert2017) == 41
@@ -34,4 +32,5 @@ def test_create_roster():
     test2020 = roster_library.create_roster('test2015',default='default2020')
     assert len(test2020) == 16
 
-test_create_roster()
+if __name__ == '__main__':
+    test_create_roster()

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Generic python script.
+Test for target creation with defaults.
 """
 __author__ = "Alex Drlica-Wagner"
 
@@ -28,6 +28,35 @@ def test_create_target():
     assert umi2020.dec == 67.2221
     assert umi2020.distance == 76.2
 
+    umi2022 = target_library.create_target('ursa_minor',default='default2022')
+    assert umi2022.ra == 227.242
+    assert umi2022.dec == 67.2221
+    assert umi2022.distance == 76.2
+
     #print(umi2020)
 
-test_create_target()
+def test_target_jfactor():
+    # Test jfactor consistency
+
+    # Build the library of pre-defined rosters
+    target_library = dmsky.targets.TargetLibrary()
+
+    target = target_library.create_target('ursa_minor:geringer-sameth2015_nfw',default='default')
+    np.testing.assert_allclose(target.j_photo(), 5.038e18, rtol=1e-3)
+    np.testing.assert_allclose(target.j_integ, 8.51e18)
+    np.testing.assert_allclose(target.j_sigma, 0.23)
+
+    target = target_library.create_target('ursa_minor:geringer-sameth2015_nfw',default='default2022')
+    np.testing.assert_allclose(target.j_photo(), 3.498e18, rtol=1e-3)
+    np.testing.assert_allclose(target.j_integ, 8.51e18)
+    np.testing.assert_allclose(target.j_sigma, 0.23)
+
+    target = target_library.create_target('ursa_minor:pace2019_nfw',default='default2022')
+    np.testing.assert_allclose(target.j_photo(), 3.498e18, rtol=1e-3)
+    np.testing.assert_allclose(target.j_integ, 5.62e18)
+    np.testing.assert_allclose(target.j_sigma, 0.12)
+
+
+if __name__ == '__main__':
+    test_create_target()
+    test_target_jfactor()


### PR DESCRIPTION
This is an update to the default dwarf dictionary, mostly to add a number of compact ultra-faint halo star systems with uncertain classification. Other modifications include
* Adding code to calculate photometric J-factors on the fly using the equation from Pace & Strigari 2019
* Updating Pace & Strigari 2019 J-factors to published version in `pace2019.yaml` and renaming `pace2018.yaml` to `pace2018v1.yaml` (fixes #21)
* Adding assorted J-factors from other papers
* Updates to tests
