### PR TITLE
Fix DELVE 6 ellipticity

### DIFF
--- a/dmsky/data/targets/dwarfs/defaults2023.yaml
+++ b/dmsky/data/targets/dwarfs/defaults2023.yaml
@@ -454,7 +454,7 @@ delve_6:
     distance: 80.0
     dsigma: 3.0
     major_axis: 0.43
-    ellipticity: .nan
+    ellipticity: 0.0 # < 0.56
     abs_mag: -1.5
     profile: {type: NFW}
 


### PR DESCRIPTION
DELVE 6 has a measured upper limit on the ellipticity at e < 0.56 from [Cerny et al. 2023](https://arxiv.org/abs/2306.04690), but the value in dmsky was set to `.nan`. I think I briefly toyed around with using `.nan` to denote upper limits, but when this is done it leads to a `.nan` value for the photo-J. I think in other cases, I reverted back to setting e = 0 when only an upper limit could be determined. This commit changes the DELVE 6 ellipticity to e = 0.